### PR TITLE
[Test] : 오디오를 재생하는 테스트가 리눅스 환경에서 무시되도록 변경

### DIFF
--- a/src/test/java/com/oreo/finalproject_5re5_be/audio/BeepMakerTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/audio/BeepMakerTest.java
@@ -1,7 +1,8 @@
 package com.oreo.finalproject_5re5_be.audio;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.sound.sampled.*;
@@ -13,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 public class BeepMakerTest {
-    private SoundPlayer soundPlayer = new SoundPlayer();
+    private final SoundPlayer soundPlayer = new SoundPlayer();
 
     @Test
-    @DisabledIfEnvironmentVariable(named = "CI", matches = "true") //테스코드가 CI 환경에서 돌아가지 않게 해주는 어노테이션
+    @DisabledOnOs({OS.LINUX}) //테스코드가 LINUX 환경에서 돌아가지 않게 해주는 어노테이션
     void makeBeepSectionTest() throws IOException {
         float duration = 0.3f;//오디오 길이 설정
         byte[] audioData = BeepMaker.makeBeep(100, duration);//오디오 생성
@@ -39,7 +40,7 @@ public class BeepMakerTest {
     }
 
     @Test
-    @DisabledIfEnvironmentVariable(named = "CI", matches = "true")//테스코드가 CI 환경에서 돌아가지 않게 해주는 어노테이션
+    @DisabledOnOs({OS.LINUX}) //테스코드가 LINUX 환경에서 돌아가지 않게 해주는 어노테이션
     void makeSilenceSectionTest() throws IOException {
         float duration = 0.3f;
         byte[] audioData = BeepMaker.makeSilence(duration);

--- a/src/test/java/com/oreo/finalproject_5re5_be/audio/SoundPlayerTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/audio/SoundPlayerTest.java
@@ -1,7 +1,8 @@
 package com.oreo.finalproject_5re5_be.audio;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.sound.sampled.*;
@@ -14,7 +15,7 @@ public class SoundPlayerTest {
     private final SoundPlayer soundPlayer = new SoundPlayer();
 
     @Test
-    @DisabledIfEnvironmentVariable(named = "CI", matches = "true")//테스코드가 CI 환경에서 돌아가지 않게 해주는 어노테이션
+    @DisabledOnOs({OS.LINUX}) //테스코드가 LINUX 환경에서 돌아가지 않게 해주는 어노테이션
     void soundPlayerTest() {
 //        File file = new File("");
 //        AudioInputStream audioInputStream = AudioSystem.getAudioInputStream(file);


### PR DESCRIPTION
## 작업 사유
- 오디오 재생 테스트 로직이 서버 환경에서 예외를 발생 시킴

## 작업 내용
- 현재 깃허브 액션이 리눅스 환경을 사용하는것을 확인
- 리눅스 환경에서 테스트가 무시되도록 수정