### PR TITLE
[Fix] : 오디오 파일 시그니처가 `00000000`로 변환 되는 오류 수정

### DIFF
--- a/src/main/java/com/oreo/finalproject_5re5_be/audio/AudioExtensionConverter.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/audio/AudioExtensionConverter.java
@@ -1,9 +1,8 @@
 package com.oreo.finalproject_5re5_be.audio;
 
-import javax.sound.sampled.AudioFormat;
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.AudioSystem;
-import javax.sound.sampled.UnsupportedAudioFileException;
+import javax.sound.sampled.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 
@@ -11,15 +10,22 @@ public class AudioExtensionConverter {
 
     private static final int DEFAULT_BIT_DEPTH = 16;
 
-    public static AudioInputStream mp3ToWav(File file) throws UnsupportedAudioFileException, IOException {
-        // 파일을 AudioInputStream으로 읽기
-        AudioInputStream audioInputStream = AudioSystem.getAudioInputStream(file);
+    public static byte[] mp3ToWav(File file) throws UnsupportedAudioFileException, IOException {
+        AudioInputStream audioInputStream = AudioSystem.getAudioInputStream(file);// 파일을 AudioInputStream으로 읽기
 
-        // WAV 포맷으로 변환
-        AudioFormat baseFormat = audioInputStream.getFormat();
+        AudioFormat baseFormat = audioInputStream.getFormat();// WAV 포맷으로 변환할 대상 포맷 설정
+        AudioFormat decodedFormat = getDecodedFormat(baseFormat);
+        AudioInputStream finalStream = getAudioInputStream(decodedFormat, audioInputStream);
 
-        //디코딩 템플릿 같은거
-        AudioFormat decodedFormat = new AudioFormat(
+        ByteArrayOutputStream wavOutputStream = new ByteArrayOutputStream();//메모리에 저장할 ByteArray
+        AudioSystem.write(finalStream, AudioFileFormat.Type.WAVE, wavOutputStream);// 메모리 내에서 WAV 형식으로 변환 및 저장
+
+        return wavOutputStream.toByteArray();// 바이트 배열 반환
+
+    }
+
+    private static AudioFormat getDecodedFormat(AudioFormat baseFormat) {
+        return new AudioFormat(
                 AudioFormat.Encoding.PCM_SIGNED,
                 baseFormat.getSampleRate(),
                 DEFAULT_BIT_DEPTH,
@@ -28,10 +34,34 @@ public class AudioExtensionConverter {
                 baseFormat.getSampleRate(),
                 false
         );
-
-        return AudioSystem.getAudioInputStream(decodedFormat, audioInputStream);
     }
 
-    //wavToMp3
+    private static AudioInputStream getAudioInputStream(
+            AudioFormat decodedFormat, AudioInputStream audioInputStream) throws IOException {
+        // 변환된 AudioInputStream
+        AudioInputStream pcmStream = AudioSystem.getAudioInputStream(decodedFormat, audioInputStream);
+
+        // 전체 데이터를 ByteArrayOutputStream에 저장하여 스트림 길이를 계산
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int bytesRead;
+        while ((bytesRead = pcmStream.read(buffer)) != -1) {
+            byteArrayOutputStream.write(buffer, 0, bytesRead);
+        }
+
+        // 데이터를 바이트 배열로 변환
+        return getAudioInputStream(decodedFormat, byteArrayOutputStream);
+    }
+
+    private static AudioInputStream getAudioInputStream(AudioFormat decodedFormat,
+                                                        ByteArrayOutputStream byteArrayOutputStream) {
+        byte[] pcmData = byteArrayOutputStream.toByteArray();
+
+        // 새로운 AudioInputStream 생성하여 길이 지정
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(pcmData);
+        return new AudioInputStream(
+                byteArrayInputStream, decodedFormat, pcmData.length / decodedFormat.getFrameSize()
+        );
+    }
 }
 


### PR DESCRIPTION
## 작업 내용
- 확장자 변환시 시그니처가 wav파일 시그니처가 아닌 `00000000` 으로 변환 되는 오류 수정
---

## 변경 사항
- 바이트 배열을 반환하도록 변경