### PR TITLE
[feat] 회원 약관 항목 개발 구현 

### DIFF
--- a/src/main/java/com/oreo/finalproject_5re5_be/member/config/MemberSecurityConfig.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/config/MemberSecurityConfig.java
@@ -57,10 +57,10 @@ public class MemberSecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource)) // 새로운 방식으로 CORS 설정 적용
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/", "/member/**", "/api/member/**", // 허용되는 URL
-                                "/audio/**", "/project/**", "/languagecode/**",
-                                "/voice/**", "/style/**", "/vc/**", "/concat/**",
-                                "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html") // Swagger 관련 URL 허용
+                        .requestMatchers("/", "/member/**", "/api/member/**", "/api/member-term-condition/**", // 허용되는 URL
+                                         "/audio/**", "/project/**", "/languagecode/**",
+                                         "/voice/**", "/style/**", "/vc/**", "/concat/**",
+                                         "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html") // Swagger 관련 URL 허용
                         .permitAll() // 위 URL들은 인증 없이 접근 가능
                 )
                 .formLogin(formLogin -> formLogin

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/controller/MemberTermConditionController.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/controller/MemberTermConditionController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+
 @RestController
 @RequestMapping("/api/member-term-condition")
 public class MemberTermConditionController {

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/controller/MemberTermConditionController.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/controller/MemberTermConditionController.java
@@ -1,0 +1,78 @@
+package com.oreo.finalproject_5re5_be.member.controller;
+
+import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionRequest;
+import com.oreo.finalproject_5re5_be.member.dto.response.ErrorResponse;
+import com.oreo.finalproject_5re5_be.member.dto.response.MemberRegisterResponse;
+import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionResponse;
+import com.oreo.finalproject_5re5_be.member.exception.MemberInvalidTermConditionException;
+import com.oreo.finalproject_5re5_be.member.service.MemberTermsConditionServiceImpl;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/member-term-condition")
+public class MemberTermConditionController {
+
+
+    private final MemberTermsConditionServiceImpl memberTermConditionService;
+
+    public MemberTermConditionController(MemberTermsConditionServiceImpl memberTermConditionService) {
+        this.memberTermConditionService = memberTermConditionService;
+    }
+
+    @ExceptionHandler(
+            MemberInvalidTermConditionException.class
+    )
+    public ResponseEntity<ErrorResponse> handleInvalidTermConditionException(RuntimeException e) {
+        // 회원 약관 항목 등록 실패시 에러 메시지 반환
+        // - 400 Bad Request 와 에러 메시지 반환
+        ErrorResponse errorResponse = ErrorResponse.of(e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                             .body(errorResponse);
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<MemberTermConditionResponse> register(@Valid @RequestBody MemberTermConditionRequest request, BindingResult result) {
+        // 유효성 검증 실패시 에러 메시지 반환
+        if (result.hasErrors()) {
+            // 에러 메시지 생성
+            String errorsMessage = createErrorMessage(result.getAllErrors());
+            // 유효성 에러 반환
+            throw new MemberInvalidTermConditionException(errorsMessage);
+        }
+
+        MemberTermConditionResponse response = memberTermConditionService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(response);
+    }
+
+
+    // 유효성 검증 실패시 에러 메시지 생성
+    private String createErrorMessage(List<ObjectError> errors) {
+        // 문자열 연산 성능을 고려한 StringBuilder 사용
+        StringBuilder sb = new StringBuilder();
+        // 에러 메시지 생성
+        sb.append("데이터 입력 형식이 잘못되었습니다. 상세 내용은 다음과 같습니다.")
+                .append("\n");
+
+        // 각 에러 객체를 조회하여 에러 메시지를 생성
+        for (ObjectError error : errors) {
+            sb.append(error.getDefaultMessage())
+                    .append("\n");
+        }
+
+        // 문자열로 반환
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/controller/MemberTermConditionController.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/controller/MemberTermConditionController.java
@@ -1,10 +1,13 @@
 package com.oreo.finalproject_5re5_be.member.controller;
 
 import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionRequest;
+import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionUpdateRequest;
 import com.oreo.finalproject_5re5_be.member.dto.response.ErrorResponse;
 import com.oreo.finalproject_5re5_be.member.dto.response.MemberRegisterResponse;
 import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionResponse;
+import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionsResponse;
 import com.oreo.finalproject_5re5_be.member.exception.MemberInvalidTermConditionException;
+import com.oreo.finalproject_5re5_be.member.exception.MemberTermsConditionNotFoundException;
 import com.oreo.finalproject_5re5_be.member.service.MemberTermsConditionServiceImpl;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -12,8 +15,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +28,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/member-term-condition")
 public class MemberTermConditionController {
-
 
     private final MemberTermsConditionServiceImpl memberTermConditionService;
 
@@ -41,6 +46,18 @@ public class MemberTermConditionController {
                              .body(errorResponse);
     }
 
+    @ExceptionHandler(
+            MemberTermsConditionNotFoundException.class
+    )
+    public ResponseEntity<ErrorResponse> handleNotFoundException(RuntimeException e) {
+        // 비즈니스 예외 발생시 에러 메시지 반환
+        // - 404 Not Found 와 에러 메시지 반환
+        ErrorResponse errorResponse = ErrorResponse.of(e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(errorResponse);
+    }
+
+    // 회원 약관 항목 등록 처리
     @PostMapping("/register")
     public ResponseEntity<MemberTermConditionResponse> register(@Valid @RequestBody MemberTermConditionRequest request, BindingResult result) {
         // 유효성 검증 실패시 에러 메시지 반환
@@ -51,9 +68,99 @@ public class MemberTermConditionController {
             throw new MemberInvalidTermConditionException(errorsMessage);
         }
 
+        // 단건 등록 처리
         MemberTermConditionResponse response = memberTermConditionService.create(request);
+        // 응답 데이터 반환
         return ResponseEntity.status(HttpStatus.CREATED)
                              .body(response);
+    }
+
+    // 회원 약관 항목 여러개 등록 처리
+    @PostMapping("/register-all")
+    public ResponseEntity<MemberTermConditionsResponse> register(@Valid @RequestBody List<MemberTermConditionRequest> requests, BindingResult result) {
+        // 유효성 검증 실패시 에러 메시지 반환
+        if (result.hasErrors()) {
+            // 에러 메시지 생성
+            String errorsMessage = createErrorMessage(result.getAllErrors());
+            // 유효성 에러 반환
+            throw new MemberInvalidTermConditionException(errorsMessage);
+        }
+
+        // 여러건 등록 처리
+        MemberTermConditionsResponse response = memberTermConditionService.create(requests);
+        // 응답 데이터 반환
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(response);
+    }
+
+    // 특정 회원 약관 항목 조회
+    @GetMapping("/{condCode}")
+    public ResponseEntity<MemberTermConditionResponse> read(@PathVariable("condCode") String condCode) {
+        // 단건 조회 처리
+        MemberTermConditionResponse response = memberTermConditionService.read(condCode);
+        // 응답 데이터 반환
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(response);
+    }
+
+    // 모든 회원 약관 항목 조회
+    @GetMapping("/all")
+    public ResponseEntity<MemberTermConditionsResponse> readAll() {
+        // 모든 조회 처리
+        MemberTermConditionsResponse response = memberTermConditionService.readAll();
+        // 응답 데이터 반환
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(response);
+    }
+
+    // 사용 가능한 약관 항목 조회
+    @GetMapping("/available")
+    public ResponseEntity<MemberTermConditionsResponse> readAvailable() {
+        // 사용 가능한 모든 조회 처리
+        MemberTermConditionsResponse response = memberTermConditionService.readAvailable();
+        // 응답 데이터 반환
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(response);
+    }
+
+    // 사용 불가능한 약관 항목 조회
+    @GetMapping("/not-available")
+    public ResponseEntity<MemberTermConditionsResponse> readNotAvailable() {
+        // 사용 불가능한 모든 조회 처리
+        MemberTermConditionsResponse response = memberTermConditionService.readNotAvailable();
+        // 응답 데이터 반환
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(response);
+    }
+
+    // 특정 약관 항목 수정
+    @PatchMapping("/{condCode}")
+    public ResponseEntity<Void> update(@PathVariable("condCode") String condCode, @RequestBody @Valid MemberTermConditionUpdateRequest request, BindingResult result) {
+        // 유효성 검증 실패시 에러 메시지 반환
+        if (result.hasErrors()) {
+            // 에러 메시지 생성
+            String errorsMessage = createErrorMessage(result.getAllErrors());
+            // 유효성 에러 반환
+            throw new MemberInvalidTermConditionException(errorsMessage);
+        }
+
+        // 수정 처리
+        memberTermConditionService.update(condCode, request);
+
+        // 응답 데이터 반환
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                             .build();
+    }
+
+    // 특정 약관 항목 삭제
+    @DeleteMapping("/{condCode}")
+    public ResponseEntity<Void> remove(@PathVariable("condCode") String condCode) {
+        // 삭제 처리
+        memberTermConditionService.remove(condCode);
+
+        // 응답 데이터 반환
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                             .build();
     }
 
 

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionRequest.java
@@ -15,9 +15,13 @@ import lombok.ToString;
 @Builder
 @ToString
 public class MemberTermConditionRequest {
+
+
     @NotBlank(message = "약관 코드를 입력해주세요.")
     @Pattern(regexp = "^[a-zA-Z0-9]{1,20}$", message = "약관 코드는 1~20자의 영문 및 숫자만 허용됩니다.")
     private String condCode;
+
+    private String name;
 
     @NotBlank(message = "약관 짧은 내용을 입력해주세요.")
     private String shortCont;
@@ -43,6 +47,7 @@ public class MemberTermConditionRequest {
         LocalDateTime now = LocalDateTime.now();
         return MemberTermsCondition.builder()
                 .condCode(condCode)
+                .name(name)
                 .shortCont(shortCont)
                 .longCont(longCont)
                 .chkUse(chkUse)
@@ -54,4 +59,5 @@ public class MemberTermConditionRequest {
                 .law3(law3)
                 .build();
     }
+
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionRequest.java
@@ -3,9 +3,11 @@ package com.oreo.finalproject_5re5_be.member.dto.request;
 import com.oreo.finalproject_5re5_be.member.entity.Member;
 import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -14,6 +16,7 @@ import lombok.ToString;
 @Setter
 @Builder
 @ToString
+@EqualsAndHashCode // 목킹 테스트를 위해 추가
 public class MemberTermConditionRequest {
 
 
@@ -29,12 +32,10 @@ public class MemberTermConditionRequest {
     @NotBlank(message = "약관 긴 내용을 입력해주세요.")
     private String longCont;
 
-    @NotBlank(message = "약관 사용 여부를 입력해주세요.")
-    @Pattern(regexp = "^[YN]$", message = "사용 여부는 Y 또는 N만 허용됩니다.")
+    @NotNull(message = "사용여부 항목의 내용을 입력해주세요.")
     private Character chkUse;
 
-    @NotBlank(message = "약관 순서를 입력해주세요.")
-    @Pattern(regexp = "^[0-9]{1,3}$", message = "순서는 1~3자의 숫자만 허용됩니다.")
+    @NotNull
     private Integer ord;
 
     private String law1;

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionRequest.java
@@ -1,7 +1,10 @@
 package com.oreo.finalproject_5re5_be.member.dto.request;
 
+import com.oreo.finalproject_5re5_be.member.entity.Member;
+import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -33,4 +36,22 @@ public class MemberTermConditionRequest {
     private String law1;
     private String law2;
     private String law3;
+
+    // Member 엔티티로 변환
+    public MemberTermsCondition createMemberTermsConditionEntity() {
+        // 현재 시간 조회
+        LocalDateTime now = LocalDateTime.now();
+        return MemberTermsCondition.builder()
+                .condCode(condCode)
+                .shortCont(shortCont)
+                .longCont(longCont)
+                .chkUse(chkUse)
+                .ord(ord)
+                .termCondDate(now)
+                .termCondUpDate(now)
+                .law1(law1)
+                .law2(law2)
+                .law3(law3)
+                .build();
+    }
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionRequest.java
@@ -1,0 +1,36 @@
+package com.oreo.finalproject_5re5_be.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class MemberTermConditionRequest {
+    @NotBlank(message = "약관 코드를 입력해주세요.")
+    @Pattern(regexp = "^[a-zA-Z0-9]{1,20}$", message = "약관 코드는 1~20자의 영문 및 숫자만 허용됩니다.")
+    private String condCode;
+
+    @NotBlank(message = "약관 짧은 내용을 입력해주세요.")
+    private String shortCont;
+
+    @NotBlank(message = "약관 긴 내용을 입력해주세요.")
+    private String longCont;
+
+    @NotBlank(message = "약관 사용 여부를 입력해주세요.")
+    @Pattern(regexp = "^[YN]$", message = "사용 여부는 Y 또는 N만 허용됩니다.")
+    private Character chkUse;
+
+    @NotBlank(message = "약관 순서를 입력해주세요.")
+    @Pattern(regexp = "^[0-9]{1,3}$", message = "순서는 1~3자의 숫자만 허용됩니다.")
+    private Integer ord;
+
+    private String law1;
+    private String law2;
+    private String law3;
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionUpdateRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionUpdateRequest.java
@@ -3,6 +3,7 @@ package com.oreo.finalproject_5re5_be.member.dto.request;
 
 import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -23,11 +24,9 @@ public class MemberTermConditionUpdateRequest {
     private String longCont;
 
 
-    @NotBlank(message = "약관 사용 여부를 입력해주세요.")
-    @Pattern(regexp = "^[YN]$", message = "사용 여부는 Y 또는 N만 허용됩니다.")
+    @NotNull(message = "약관 사용 여부를 입력해주세요.")
     private Character chkUse;
 
-    @NotBlank(message = "약관 순서를 입력해주세요.")
-    @Pattern(regexp = "^[0-9]{1,3}$", message = "순서는 1~3자의 숫자만 허용됩니다.")
+    @NotNull(message = "약관 순서를 입력해주세요.")
     private Integer ord;
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionUpdateRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/MemberTermConditionUpdateRequest.java
@@ -1,0 +1,33 @@
+package com.oreo.finalproject_5re5_be.member.dto.request;
+
+
+import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class MemberTermConditionUpdateRequest {
+
+    @NotBlank(message = "약관 짧은 내용을 입력해주세요.")
+    private String shortCont;
+
+    @NotBlank(message = "약관 긴 내용을 입력해주세요.")
+    private String longCont;
+
+
+    @NotBlank(message = "약관 사용 여부를 입력해주세요.")
+    @Pattern(regexp = "^[YN]$", message = "사용 여부는 Y 또는 N만 허용됩니다.")
+    private Character chkUse;
+
+    @NotBlank(message = "약관 순서를 입력해주세요.")
+    @Pattern(regexp = "^[0-9]{1,3}$", message = "순서는 1~3자의 숫자만 허용됩니다.")
+    private Integer ord;
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberTermConditionResponse.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberTermConditionResponse.java
@@ -1,14 +1,17 @@
 package com.oreo.finalproject_5re5_be.member.dto.response;
 
+import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
 @Getter
 @ToString
+@NoArgsConstructor
 public class MemberTermConditionResponse {
     private String condCode;
     private String shortCont;
@@ -18,4 +21,15 @@ public class MemberTermConditionResponse {
     private String law1;
     private String law2;
     private String law3;
+
+    public MemberTermConditionResponse(MemberTermsCondition memberTermsCondition) {
+        this.condCode = memberTermsCondition.getCondCode();
+        this.shortCont = memberTermsCondition.getShortCont();
+        this.longCont = memberTermsCondition.getLongCont();
+        this.chkUse = memberTermsCondition.getChkUse();
+        this.ord = memberTermsCondition.getOrd();
+        this.law1 = memberTermsCondition.getLaw1();
+        this.law2 = memberTermsCondition.getLaw2();
+        this.law3 = memberTermsCondition.getLaw3();
+    }
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberTermConditionResponse.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberTermConditionResponse.java
@@ -1,0 +1,21 @@
+package com.oreo.finalproject_5re5_be.member.dto.response;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class MemberTermConditionResponse {
+    private String condCode;
+    private String shortCont;
+    private String longCont;
+    private Character chkUse;
+    private Integer ord;
+    private String law1;
+    private String law2;
+    private String law3;
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberTermConditionsResponse.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberTermConditionsResponse.java
@@ -1,0 +1,22 @@
+package com.oreo.finalproject_5re5_be.member.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class MemberTermConditionsResponse {
+
+    List<MemberTermConditionResponse> memberTermConditionResponses;
+
+    public MemberTermConditionsResponse(List<MemberTermConditionResponse> memberTermConditionResponses) {
+        this.memberTermConditionResponses = memberTermConditionResponses;
+    }
+
+    public List<MemberTermConditionResponse> getMemberTermConditionResponses() {
+        return memberTermConditionResponses;
+    }
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberTermUpdateResponse.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberTermUpdateResponse.java
@@ -1,0 +1,5 @@
+package com.oreo.finalproject_5re5_be.member.dto.response;
+
+public class MemberTermUpdateResponse {
+
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberTermUpdateResponse.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberTermUpdateResponse.java
@@ -1,5 +1,0 @@
-package com.oreo.finalproject_5re5_be.member.dto.response;
-
-public class MemberTermUpdateResponse {
-
-}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTerms.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTerms.java
@@ -44,6 +44,7 @@ public class MemberTerms extends BaseEntity  {
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "term_code_3")
     private MemberTermsCondition termCode3;
+
     @Column(name = "chk_term_3")
     private Character chkTerm3;
 

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
@@ -42,6 +42,10 @@ public class MemberTermsCondition extends BaseEntity  {
     private String longCont;
     @Column(name = "chk_use", nullable = false)
     private Character chkUse;
+
+    @Column(name = "ord", nullable = false)
+    private Integer ord;
+
     @Column(name = "term_cond_date", nullable = false)
     private LocalDateTime termCondDate;
     @Column(name = "term_cond_up_date")

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
@@ -32,7 +32,7 @@ public class MemberTermsCondition extends BaseEntity  {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long termCondSeq;
 
-    @Column(name = "terms_cond_code", nullable = false)
+    @Column(name = "cond_code", nullable = false)
     private String condCode;
 
     @Column(name = "name", nullable = false)

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
@@ -32,7 +32,7 @@ public class MemberTermsCondition extends BaseEntity  {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long termCondSeq;
 
-    @Column(name = "terms_cond_code", nullable = false, unique = true)
+    @Column(name = "terms_cond_code", nullable = false)
     private String condCode;
 
     @Column(name = "name", nullable = false)

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
@@ -20,9 +20,13 @@ import lombok.ToString;
 public class MemberTermsCondition extends BaseEntity  {
 
     @Id
-    @Column(name = "terms_cond_code")
+    @Column(name = "terms_cond_seq")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long termCondCode;
+    private Long termCondSeq;
+
+    @Column(name = "terms_cond_code", nullable = false, unique = true)
+    private String condCode;
+
     @Column(name = "name", nullable = false)
     private String name;
     @Column(name = "short_cont", nullable = false)

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
@@ -8,7 +8,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -16,6 +20,9 @@ import lombok.ToString;
 @Entity
 @Table(name = "member_terms_condition")
 @Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @ToString
 public class MemberTermsCondition extends BaseEntity  {
 

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/MemberTermsCondition.java
@@ -1,6 +1,7 @@
 package com.oreo.finalproject_5re5_be.member.entity;
 
 import com.oreo.finalproject_5re5_be.global.entity.BaseEntity;
+import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -56,4 +57,12 @@ public class MemberTermsCondition extends BaseEntity  {
     private String law2;
     @Column(name = "law3")
     private String law3;
+
+    public void update(MemberTermConditionUpdateRequest updateRequest) {
+        this.shortCont = updateRequest.getShortCont();
+        this.longCont = updateRequest.getLongCont();
+        this.chkUse = updateRequest.getChkUse();
+        this.ord = updateRequest.getOrd();
+        this.termCondUpDate = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/exception/MemberInvalidTermConditionException.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/exception/MemberInvalidTermConditionException.java
@@ -1,0 +1,13 @@
+package com.oreo.finalproject_5re5_be.member.exception;
+
+public class MemberInvalidTermConditionException extends RuntimeException {
+
+        public MemberInvalidTermConditionException() {
+            this("약관이 유효하지 않습니다.");
+        }
+
+        public MemberInvalidTermConditionException(String message) {
+            super(message);
+        }
+
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/exception/MemberTermsConditionNotFoundException.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/exception/MemberTermsConditionNotFoundException.java
@@ -1,0 +1,12 @@
+package com.oreo.finalproject_5re5_be.member.exception;
+
+public class MemberTermsConditionNotFoundException extends RuntimeException{
+
+    public MemberTermsConditionNotFoundException() {
+        this("약관이 존재하지 않습니다.");
+    }
+
+    public MemberTermsConditionNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepository.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepository.java
@@ -1,0 +1,10 @@
+package com.oreo.finalproject_5re5_be.member.repository;
+
+import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberTermConditionRepository extends JpaRepository<MemberTermsCondition, Long> {
+
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepository.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepository.java
@@ -16,4 +16,10 @@ public interface MemberTermConditionRepository extends JpaRepository<MemberTerms
             "WHERE mtc.chkUse = 'Y' " +
             "ORDER BY mtc.ord")
     public List<MemberTermsCondition> findAvailableMemberTermsConditions();
+
+    @Query( "SELECT mtc " +
+            "FROM MemberTermsCondition mtc " +
+            "WHERE mtc.chkUse = 'N' " +
+            "ORDER BY mtc.ord")
+    public List<MemberTermsCondition> findNotAvailableMemberTermsConditions();
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepository.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepository.java
@@ -1,10 +1,19 @@
 package com.oreo.finalproject_5re5_be.member.repository;
 
 import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberTermConditionRepository extends JpaRepository<MemberTermsCondition, Long> {
 
+    public MemberTermsCondition findMemberTermsConditionByCondCode(String condCode);
+
+    @Query( "SELECT mtc " +
+            "FROM MemberTermsCondition mtc " +
+            "WHERE mtc.chkUse = 'Y' " +
+            "ORDER BY mtc.ord")
+    public List<MemberTermsCondition> findAvailableMemberTermsConditions();
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImpl.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImpl.java
@@ -50,11 +50,54 @@ public class MemberTermsConditionServiceImpl {
     }
 
     // 2-1. 단건 회원 약관 항목을 조회한다
-    // 2-2. 여러개 회원 약관 항목을 조회한다
+    public MemberTermConditionResponse read(String condCode) {
+        // 특정 약관 항목 코드로 조회
+        MemberTermsCondition foundMemberTermsCondition = memberTermConditionRepository.findMemberTermsConditionByCondCode(condCode);
+        // 조회된 엔티티를 response로 변환하여 반환한다
+        return new MemberTermConditionResponse(foundMemberTermsCondition);
+    }
+
+    // 2-2. 모든 회원 약관 항목을 조회한다
+    @Transactional(readOnly = true)
+    public MemberTermConditionsResponse readAll() {
+        // 모든 회원 약관 항목을 조회한다
+        List<MemberTermsCondition> foundMemberTermsConditions = memberTermConditionRepository.findAll();
+        // 조회된 엔티티를 response로 변환하여 반환한다
+        List<MemberTermConditionResponse> memberTermCondtionsResponse = foundMemberTermsConditions.stream()
+                                                                                                 .map(MemberTermConditionResponse::new)
+                                                                                                 .toList();
+        // 조회된 엔티티를 response로 변환하여 반환한다
+        return new MemberTermConditionsResponse(memberTermCondtionsResponse);
+    }
+
     // 2-2. 사용 가능한 여러개 회원 약관 항목을 조회한다
+    @Transactional(readOnly = true)
+    public MemberTermConditionsResponse readAvailable() {
+        // 사용 가능한 여러개 회원 약관 항목을 조회한다
+        List<MemberTermsCondition> availableMemberTermsConditions = memberTermConditionRepository.findAvailableMemberTermsConditions();
+
+        // 조회된 엔티티 더미를 response로 변환하여 반환한다
+        List<MemberTermConditionResponse> memberTermConditionResponses = availableMemberTermsConditions.stream()
+                                                                                                      .map(MemberTermConditionResponse::new)
+                                                                                                      .toList();
+        return new MemberTermConditionsResponse(memberTermConditionResponses);
+    }
+
     // 2-3. 사용 불가능한 여러개 회원 약관 항목을 조회한다
+    @Transactional(readOnly = true)
+    public MemberTermConditionsResponse readNotAvailable() {
+        // 사용 가능한 여러개 회원 약관 항목을 조회한다
+        List<MemberTermsCondition> availableMemberTermsConditions = memberTermConditionRepository.findNotAvailableMemberTermsConditions();
+
+        // 조회된 엔티티 더미를 response로 변환하여 반환한다
+        List<MemberTermConditionResponse> memberTermConditionResponses = availableMemberTermsConditions.stream()
+                                                                                                       .map(MemberTermConditionResponse::new)
+                                                                                                       .toList();
+        return new MemberTermConditionsResponse(memberTermConditionResponses);
+    }
 
     // 3-1. 단건 회원 약관 항목을 수정한다
+
     // 3-2. 여러개 회원 약관 항목을 수정한다
 
     // 4-1. 단건 회원 약관 항목을 삭제한다

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImpl.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImpl.java
@@ -55,6 +55,11 @@ public class MemberTermsConditionServiceImpl {
     public MemberTermConditionResponse read(String condCode) {
         // 특정 약관 항목 코드로 조회
         MemberTermsCondition foundMemberTermsCondition = memberTermConditionRepository.findMemberTermsConditionByCondCode(condCode);
+        if (foundMemberTermsCondition == null) {
+            // 없을 경우 예외 발생
+             throw new MemberTermsConditionNotFoundException();
+        }
+
         // 조회된 엔티티를 response로 변환하여 반환한다
         return new MemberTermConditionResponse(foundMemberTermsCondition);
     }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImpl.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImpl.java
@@ -1,7 +1,15 @@
 package com.oreo.finalproject_5re5_be.member.service;
 
+import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionRequest;
+import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionResponse;
+import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionsResponse;
+import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
 import com.oreo.finalproject_5re5_be.member.repository.MemberTermConditionRepository;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MemberTermsConditionServiceImpl {
@@ -13,7 +21,33 @@ public class MemberTermsConditionServiceImpl {
     }
     // 회원 약관 항목 CRUD
     // 1-1. 단건 회원 약관 항목을 등록한다
+    public MemberTermConditionResponse create(MemberTermConditionRequest request) {
+        // 유효성 검증이 완료된 request로부터 엔티티를 생성한다
+        MemberTermsCondition memberTermsConditionEntity = request.createMemberTermsConditionEntity();
+        // 생성된 엔티티를 저장한다
+        MemberTermsCondition savedMemberTermsCondition = memberTermConditionRepository.save(memberTermsConditionEntity);
+        // 저장된 엔티티를 response로 변환하여 반환한다
+        return new MemberTermConditionResponse(savedMemberTermsCondition);
+    }
+
     // 1-2. 여러개 회원 약관 항목을 등록한다
+    @Transactional
+    public MemberTermConditionsResponse create(List<MemberTermConditionRequest> requests) {
+        // 유효성 검증이 완료된 requests 더미로부터 이터러블 할 수 있는 엔티티 더미를 생성한다
+        Stream<MemberTermsCondition> memberTermConditions = requests.stream()
+                                                                    .map(MemberTermConditionRequest::createMemberTermsConditionEntity);
+
+        // 해당 엔티티 더미를 모두 저장한다
+        List<MemberTermsCondition> savedMemberTermConditions = memberTermConditionRepository.saveAll(memberTermConditions::iterator);
+
+        // 저장된 엔티티 더미를 각각 response로 변환하여 반환한다
+        List<MemberTermConditionResponse> memberTermCondtionsResponse = savedMemberTermConditions.stream()
+                                                                                                 .map(MemberTermConditionResponse::new)
+                                                                                                 .toList();
+
+        // 저장된 엔티티 더미를 response로 변환하여 반환한다
+        return new MemberTermConditionsResponse(memberTermCondtionsResponse);
+    }
 
     // 2-1. 단건 회원 약관 항목을 조회한다
     // 2-2. 여러개 회원 약관 항목을 조회한다

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImpl.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImpl.java
@@ -1,9 +1,11 @@
 package com.oreo.finalproject_5re5_be.member.service;
 
 import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionRequest;
+import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionUpdateRequest;
 import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionResponse;
 import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionsResponse;
 import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
+import com.oreo.finalproject_5re5_be.member.exception.MemberTermsConditionNotFoundException;
 import com.oreo.finalproject_5re5_be.member.repository.MemberTermConditionRepository;
 import java.util.Iterator;
 import java.util.List;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class MemberTermsConditionServiceImpl {
 
     private final MemberTermConditionRepository memberTermConditionRepository;
@@ -31,7 +34,6 @@ public class MemberTermsConditionServiceImpl {
     }
 
     // 1-2. 여러개 회원 약관 항목을 등록한다
-    @Transactional
     public MemberTermConditionsResponse create(List<MemberTermConditionRequest> requests) {
         // 유효성 검증이 완료된 requests 더미로부터 이터러블 할 수 있는 엔티티 더미를 생성한다
         Stream<MemberTermsCondition> memberTermConditions = requests.stream()
@@ -97,11 +99,30 @@ public class MemberTermsConditionServiceImpl {
     }
 
     // 3-1. 단건 회원 약관 항목을 수정한다
+    public void update(String condCode, MemberTermConditionUpdateRequest request) {
+        // 특정 약관 항목 코드로 약과 조회
+        MemberTermsCondition foundMemberTermCondition = memberTermConditionRepository.findMemberTermsConditionByCondCode(condCode);
+        if (foundMemberTermCondition == null) {
+            // 없을 경우 예외 발생
+             throw new MemberTermsConditionNotFoundException();
+        }
+        // 있을 경우 엔티티를 수정
+        foundMemberTermCondition.update(request);
+    }
 
-    // 3-2. 여러개 회원 약관 항목을 수정한다
 
     // 4-1. 단건 회원 약관 항목을 삭제한다
-    // 4-2. 여러개 회원 약관 항목을 삭제한다
+    public void remove(String condCode) {
+        // 특정 약관 항목 코드로 약관을 조회한다
+        MemberTermsCondition foundMemberTermCondition = memberTermConditionRepository.findMemberTermsConditionByCondCode(condCode);
+        if (foundMemberTermCondition == null) {
+            // 없을 경우 예외 발생
+             throw new MemberTermsConditionNotFoundException();
+        }
+
+        // 조회된 약관을 삭제한다
+        memberTermConditionRepository.delete(foundMemberTermCondition);
+    }
 
 
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImpl.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImpl.java
@@ -1,0 +1,30 @@
+package com.oreo.finalproject_5re5_be.member.service;
+
+import com.oreo.finalproject_5re5_be.member.repository.MemberTermConditionRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberTermsConditionServiceImpl {
+
+    private final MemberTermConditionRepository memberTermConditionRepository;
+
+    public MemberTermsConditionServiceImpl(MemberTermConditionRepository memberTermConditionRepository) {
+        this.memberTermConditionRepository = memberTermConditionRepository;
+    }
+    // 회원 약관 항목 CRUD
+    // 1-1. 단건 회원 약관 항목을 등록한다
+    // 1-2. 여러개 회원 약관 항목을 등록한다
+
+    // 2-1. 단건 회원 약관 항목을 조회한다
+    // 2-2. 여러개 회원 약관 항목을 조회한다
+    // 2-2. 사용 가능한 여러개 회원 약관 항목을 조회한다
+    // 2-3. 사용 불가능한 여러개 회원 약관 항목을 조회한다
+
+    // 3-1. 단건 회원 약관 항목을 수정한다
+    // 3-2. 여러개 회원 약관 항목을 수정한다
+
+    // 4-1. 단건 회원 약관 항목을 삭제한다
+    // 4-2. 여러개 회원 약관 항목을 삭제한다
+
+
+}

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/controller/MemberControllerTest.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oreo.finalproject_5re5_be.member.dto.request.MemberRegisterRequest;
 import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermRequest;
 import com.oreo.finalproject_5re5_be.member.dto.response.MemberReadResponse;
-import com.oreo.finalproject_5re5_be.member.dto.response.MemberRegisterResponse;
 import com.oreo.finalproject_5re5_be.member.entity.Member;
 import com.oreo.finalproject_5re5_be.member.exception.MemberNotFoundException;
 import com.oreo.finalproject_5re5_be.member.service.MemberServiceImpl;

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/controller/MemberTermConditionControllerTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/controller/MemberTermConditionControllerTest.java
@@ -1,0 +1,474 @@
+package com.oreo.finalproject_5re5_be.member.controller;
+
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionRequest;
+import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionUpdateRequest;
+import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionResponse;
+import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionsResponse;
+import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
+import com.oreo.finalproject_5re5_be.member.exception.MemberTermsConditionNotFoundException;
+import com.oreo.finalproject_5re5_be.member.service.MemberTermsConditionServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+@RunWith(SpringRunner.class)
+@AutoConfigureMockMvc
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application-test.properties")
+class MemberTermConditionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberTermsConditionServiceImpl memberTermsConditionService;
+
+    @BeforeEach
+    void setUp() {
+        assertNotNull(mockMvc);
+        assertNotNull(objectMapper);
+        assertNotNull(memberTermsConditionService);
+    }
+
+    @DisplayName("회원 약관 등록 처리")
+    @Test
+    void 회원_약관_등록_처리() throws Exception {
+        // 요청 데이터 생성
+        MemberTermConditionRequest request = MemberTermConditionRequest.builder()
+                .condCode("mtc01")
+                .name("이용약관")
+                .shortCont("짧은 이용약관 설명")
+                .longCont("긴 이용약관 설명")
+                .chkUse('Y')
+                .ord(1)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build();
+
+        MemberTermsCondition savedMemberTermCondition = request.createMemberTermsConditionEntity();
+        MemberTermConditionResponse response = new MemberTermConditionResponse(savedMemberTermCondition);
+
+        // 요청 데이터 서비스에 전달하면 생성됐다고 반환하게 설정
+        // 목킹 제대로 안되고 null 반환하는 경우 있음. 이 부분 equals, hashcode 구현해서 잡을 수 있음
+        when(memberTermsConditionService.create(request)).thenReturn(response);
+
+        // 요청 데이터 컨트롤러에 전달
+        // 응답 데이터 확인
+        mockMvc.perform(post("/api/member-term-condition/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.condCode").value(response.getCondCode()))
+                .andExpect(jsonPath("$.shortCont").value(response.getShortCont()))
+                .andExpect(jsonPath("$.longCont").value(response.getLongCont()))
+                .andExpect(jsonPath("$.chkUse").value(response.getChkUse().toString()))
+                .andExpect(jsonPath("$.ord").value(response.getOrd()))
+                .andExpect(jsonPath("$.law1").value(response.getLaw1()))
+                .andExpect(jsonPath("$.law2").value(response.getLaw2()))
+                .andExpect(jsonPath("$.law3").value(response.getLaw3()));
+    }
+
+    @DisplayName("회원 약관 여러개 등록 처리")
+    @Test
+    void 회원_여러개_약관_등록_처리() throws Exception {
+        // 요청 데이터 여러개 생성
+        List<MemberTermConditionRequest> requests = new ArrayList<>();
+        requests.add(MemberTermConditionRequest.builder()
+                .condCode("mtc01")
+                .name("이용약관")
+                .shortCont("짧은 이용약관 설명")
+                .longCont("긴 이용약관 설명")
+                .chkUse('Y')
+                .ord(1)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        requests.add(MemberTermConditionRequest.builder()
+                .condCode("mtc02")
+                .name("개인정보처리방침")
+                .shortCont("짧은 개인정보처리방침 설명")
+                .longCont("긴 개인정보처리방침 설명")
+                .chkUse('Y')
+                .ord(2)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        requests.add(MemberTermConditionRequest.builder()
+                .condCode("mtc03")
+                .name("위치기반서비스 이용약관")
+                .shortCont("짧은 위치기반서비스 이용약관 설명")
+                .longCont("긴 위치기반서비스 이용약관 설명")
+                .chkUse('Y')
+                .ord(3)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        // 기대 결과 데이터 생성
+        List<MemberTermConditionResponse> savedMemberTermsConditions = new ArrayList<>();
+        for (MemberTermConditionRequest request : requests) {
+            MemberTermsCondition memberTermsConditionEntity = request.createMemberTermsConditionEntity();
+            MemberTermConditionResponse memberTermConditionResponse = new MemberTermConditionResponse(memberTermsConditionEntity);
+            savedMemberTermsConditions.add(memberTermConditionResponse);
+        }
+
+        MemberTermConditionsResponse memberTermConditionsResponse = new MemberTermConditionsResponse(savedMemberTermsConditions);
+        when(memberTermsConditionService.create(requests)).thenReturn(memberTermConditionsResponse);
+
+
+        // 컨트롤러에 요청 보내고 응답 확인
+        mockMvc.perform(post("/api/member-term-condition/register-all")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requests))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.memberTermConditionResponses[0].condCode").value(savedMemberTermsConditions.get(0).getCondCode()));
+    }
+
+    @DisplayName("회원 약관 조회 처리")
+    @Test
+    void 회원_약관_조회_처리() throws Exception {
+        // 서비스에서 응답할 데이터 생성
+        MemberTermConditionRequest request = MemberTermConditionRequest.builder()
+                .condCode("mtc01")
+                .name("이용약관")
+                .shortCont("짧은 이용약관 설명")
+                .longCont("긴 이용약관 설명")
+                .chkUse('Y')
+                .ord(1)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build();
+
+        MemberTermsCondition savedMemberTermCondition = request.createMemberTermsConditionEntity();
+        MemberTermConditionResponse response = new MemberTermConditionResponse(savedMemberTermCondition);
+
+        // 서비스 세팅
+        when(memberTermsConditionService.read("mtc01")).thenReturn(response);
+
+        // 컨트롤러 요청 보내기 및 내용 비교
+        mockMvc.perform(get("/api/member-term-condition/mtc01"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.condCode").value(response.getCondCode()))
+                .andExpect(jsonPath("$.shortCont").value(response.getShortCont()))
+                .andExpect(jsonPath("$.longCont").value(response.getLongCont()))
+                .andExpect(jsonPath("$.chkUse").value(response.getChkUse().toString()))
+                .andExpect(jsonPath("$.ord").value(response.getOrd()))
+                .andExpect(jsonPath("$.law1").value(response.getLaw1()))
+                .andExpect(jsonPath("$.law2").value(response.getLaw2()))
+                .andExpect(jsonPath("$.law3").value(response.getLaw3()));
+    }
+
+    @DisplayName("회원 약관 모두 조회 처리")
+    @Test
+    void 회원_약관_모두_조회_처리() throws Exception {
+        // 조회될 데이터 생성
+        List<MemberTermConditionRequest> dummy = new ArrayList<>();
+        dummy.add(MemberTermConditionRequest.builder()
+                .condCode("mtc01")
+                .name("이용약관")
+                .shortCont("짧은 이용약관 설명")
+                .longCont("긴 이용약관 설명")
+                .chkUse('Y')
+                .ord(1)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        dummy.add(MemberTermConditionRequest.builder()
+                .condCode("mtc02")
+                .name("개인정보처리방침")
+                .shortCont("짧은 개인정보처리방침 설명")
+                .longCont("긴 개인정보처리방침 설명")
+                .chkUse('Y')
+                .ord(2)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        dummy.add(MemberTermConditionRequest.builder()
+                .condCode("mtc03")
+                .name("위치기반서비스 이용약관")
+                .shortCont("짧은 위치기반서비스 이용약관 설명")
+                .longCont("긴 위치기반서비스 이용약관 설명")
+                .chkUse('Y')
+                .ord(3)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        // 서비스에서 응답할 데이터 생성
+        List<MemberTermConditionResponse> savedMemberTermsConditions = new ArrayList<>();
+        for (MemberTermConditionRequest request : dummy) {
+            MemberTermsCondition memberTermsConditionEntity = request.createMemberTermsConditionEntity();
+            MemberTermConditionResponse response = new MemberTermConditionResponse(
+                    memberTermsConditionEntity);
+            savedMemberTermsConditions.add(response);
+        }
+        MemberTermConditionsResponse response = new MemberTermConditionsResponse(savedMemberTermsConditions);
+        when(memberTermsConditionService.readAll()).thenReturn(response);
+
+        // 컨트롤러에 요청 보내기
+        // 응답 데이터 확인
+        mockMvc.perform(get("/api/member-term-condition/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberTermConditionResponses[0].condCode").value(savedMemberTermsConditions.get(0).getCondCode()));
+    }
+
+    @DisplayName("사용 가능한 약관 항목 조회 처리")
+    @Test
+    void 사용_가능한_약관_항목_조회_처리() throws Exception {
+        // 더미 데이터 생성
+        List<MemberTermConditionRequest> dummy = new ArrayList<>();
+        dummy.add(MemberTermConditionRequest.builder()
+                .condCode("mtc01")
+                .name("이용약관")
+                .shortCont("짧은 이용약관 설명")
+                .longCont("긴 이용약관 설명")
+                .chkUse('Y')
+                .ord(1)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        dummy.add(MemberTermConditionRequest.builder()
+                .condCode("mtc02")
+                .name("개인정보처리방침")
+                .shortCont("짧은 개인정보처리방침 설명")
+                .longCont("긴 개인정보처리방침 설명")
+                .chkUse('Y')
+                .ord(2)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        dummy.add(MemberTermConditionRequest.builder()
+                .condCode("mtc03")
+                .name("위치기반서비스 이용약관")
+                .shortCont("짧은 위치기반서비스 이용약관 설명")
+                .longCont("긴 위치기반서비스 이용약관 설명")
+                .chkUse('N')
+                .ord(3)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        // 서비스에서 응답될 데이터 세팅
+        List<MemberTermConditionResponse> savedMemberTermsConditions = new ArrayList<>();
+        for (MemberTermConditionRequest request : dummy) {
+            if (request.getChkUse().equals('N')) continue;
+
+            MemberTermsCondition memberTermsConditionEntity = request.createMemberTermsConditionEntity();
+            MemberTermConditionResponse response = new MemberTermConditionResponse(memberTermsConditionEntity);
+            savedMemberTermsConditions.add(response);
+        }
+
+        MemberTermConditionsResponse response = new MemberTermConditionsResponse(savedMemberTermsConditions);
+        when(memberTermsConditionService.readAvailable()).thenReturn(response);
+
+
+        // 컨트롤러에 요청 보내기
+        // 응답 데이터 확인
+        mockMvc.perform(get("/api/member-term-condition/available"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberTermConditionResponses[0].condCode").value(savedMemberTermsConditions.get(0).getCondCode()));
+
+    }
+
+    @DisplayName("사용 불가능한 약관 항목 조회 처리")
+    @Test
+    void 사용_불가능한_약관_항목_조회_처리() throws Exception {
+        // 더미 데이터 생성
+        List<MemberTermConditionRequest> dummy = new ArrayList<>();
+        dummy.add(MemberTermConditionRequest.builder()
+                .condCode("mtc01")
+                .name("이용약관")
+                .shortCont("짧은 이용약관 설명")
+                .longCont("긴 이용약관 설명")
+                .chkUse('Y')
+                .ord(1)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        dummy.add(MemberTermConditionRequest.builder()
+                .condCode("mtc02")
+                .name("개인정보처리방침")
+                .shortCont("짧은 개인정보처리방침 설명")
+                .longCont("긴 개인정보처리방침 설명")
+                .chkUse('Y')
+                .ord(2)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        dummy.add(MemberTermConditionRequest.builder()
+                .condCode("mtc03")
+                .name("위치기반서비스 이용약관")
+                .shortCont("짧은 위치기반서비스 이용약관 설명")
+                .longCont("긴 위치기반서비스 이용약관 설명")
+                .chkUse('N')
+                .ord(3)
+                .law1("법률1")
+                .law2("법률2")
+                .law3("법률3")
+                .build());
+
+        // 서비스에서 응답될 데이터 세팅
+        List<MemberTermConditionResponse> savedMemberTermsConditions = new ArrayList<>();
+        for (MemberTermConditionRequest request : dummy) {
+            if (request.getChkUse().equals('Y')) continue;
+
+            MemberTermsCondition memberTermsConditionEntity = request.createMemberTermsConditionEntity();
+            MemberTermConditionResponse response = new MemberTermConditionResponse(memberTermsConditionEntity);
+            savedMemberTermsConditions.add(response);
+        }
+
+        MemberTermConditionsResponse response = new MemberTermConditionsResponse(savedMemberTermsConditions);
+        when(memberTermsConditionService.readNotAvailable()).thenReturn(response);
+
+
+        // 컨트롤러에 요청 보내기
+        // 응답 데이터 확인
+        mockMvc.perform(get("/api/member-term-condition/not-available"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberTermConditionResponses[0].condCode").value(savedMemberTermsConditions.get(0).getCondCode()));
+
+    }
+
+    @DisplayName("특정 회원 약관 항목 수정 처리")
+    @Test
+    void 특정_회원_약관_항목_수정_처리() throws Exception {
+        // 업데이트될 더미 데이터 생성
+        String condCode = "mtc01";
+        MemberTermConditionUpdateRequest request = MemberTermConditionUpdateRequest.builder()
+                .shortCont("짧은 이용약관 설명 수정")
+                .longCont("긴 이용약관 설명 수정")
+                .chkUse('N')
+                .ord(2)
+                .build();
+
+        // 서비스에서 응답할 데이터 생성
+        doNothing().when(memberTermsConditionService).update(condCode, request);
+
+        // 컨트롤러에 요청 보내기
+        // 응답 데이터 확인
+        mockMvc.perform(patch("/api/member-term-condition/mtc01")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("특정 회원 약관 항목 삭제 처리")
+    @Test
+    void 특정_회원_약관_항목_삭제_처리() throws Exception {
+        // 삭제될 더미 데이터 생성 및 세팅
+        String condCode = "mtc01";
+
+        // 서비스에서 응답 동작 세팅
+        doNothing().when(memberTermsConditionService).remove(condCode);
+
+        // 컨트롤러에 요청 보내기
+        // 응답 데이터 확인
+        mockMvc.perform(delete("/api/member-term-condition/mtc01"))
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("회원 약관 항목 등록 실패시 예외 처리")
+    @Test
+    void 회원_약관_항목_등록_실패시_예외_처리() throws Exception{
+        // 예외 발생 시킬 더미 데이터 세팅
+        MemberTermConditionRequest request = MemberTermConditionRequest.builder()
+                .shortCont("짧은 이용약관 설명 수정")
+                .longCont("긴 이용약관 설명 수정")
+                .chkUse(null)
+                .ord(null)
+                .build();
+
+        // 컨트롤러에 요청 보내기
+        // 예외 처리 확인
+        mockMvc.perform(post("/api/member-term-condition/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("회원 약관 항목 수정 실패시 예외 처리")
+    @Test
+    void 회원_약관_항목_수정_실패시_예외_처리() throws Exception {
+        // 예외 발생 시킬 더미 데이터 세팅
+        MemberTermConditionUpdateRequest request = MemberTermConditionUpdateRequest.builder()
+                .shortCont("짧은 이용약관 설명 수정")
+                .longCont("긴 이용약관 설명 수정")
+                .chkUse(null)
+                .ord(null)
+                .build();
+
+        // 컨트롤러에 요청 보내기
+        // 예외 처리 확인
+        mockMvc.perform(post("/api/member-term-condition/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("회원 약관 항목 조회 실패시 예외 처리")
+    @Test
+    void 회원_약관_항목_조회_실패시_예외_처리() throws Exception {
+        // 예외 발생 시킬 더미 데이터 세팅
+        String condCode = "mtc01";
+        // 서비스에서 예외 발생하게 설정
+        when(memberTermsConditionService.read(condCode)).thenThrow(MemberTermsConditionNotFoundException.class);
+
+        // 컨트롤러에 요청 보내기
+        // 예외 처리 확인
+        mockMvc.perform(get("/api/member-term-condition/mtc01"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepositoryTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepositoryTest.java
@@ -3,9 +3,12 @@ package com.oreo.finalproject_5re5_be.member.repository;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
@@ -22,14 +25,199 @@ class MemberTermConditionRepositoryTest {
     @BeforeEach
     void setUp() {
         assertNotNull(memberTermConditionRepository);
+        // 초가화
+        dummy.clear();
         memberTermConditionRepository.deleteAll();
 
-        // 더미 생성
+        // 더미 생성 및 저장
+        createDummy();
+        memberTermConditionRepository.saveAll(dummy);
+    }
 
-        // 더미 저장
+    @DisplayName("약관 항목 코드 번호로 조회")
+    @Test
+    void 약관_항목_코드_번호_조회_성공() {
+        // 특정 약관 항목 코드로 조회
+        String condCode = "TC-001";
+        MemberTermsCondition expectedMemberTermsCondition = dummy.get(0);
+        MemberTermsCondition foundMemberTermsCondition = memberTermConditionRepository.findMemberTermsConditionByCondCode(condCode);
+        // 기대하는 결과와 조횐한 결과가 같은지 비교
+        assertTrue(isSameMemberTermsCondition(expectedMemberTermsCondition, foundMemberTermsCondition));
+    }
+
+    @DisplayName("사용 가능한 약관 정렬 순서대로 조회")
+    @Test
+    void 사용_가능한_약관_정렬_순서대로_조회_성공() {
+        // 사용 가능한 약관을 저장되어 있는 정렬 순서에 따라 조회
+        List<MemberTermsCondition> foundAvailableMemberTermsCondtions = memberTermConditionRepository.findAvailableMemberTermsConditions();
+
+        // 위의 더미와 같은지 비교
+        int expectedSize = dummy.size();
+        assertEquals(expectedSize, foundAvailableMemberTermsCondtions.size());
+
+        // 반복 순회하면서 내용 비교
+        for (int i = 0; i < expectedSize; i++) {
+            MemberTermsCondition expected = dummy.get(i);
+            MemberTermsCondition found = foundAvailableMemberTermsCondtions.get(i);
+            assertTrue(isSameMemberTermsCondition(expected, found));
+        }
+    }
+
+    private boolean isSameMemberTermsCondition(MemberTermsCondition expected, MemberTermsCondition actual) {
+        return expected.getCondCode().equals(actual.getCondCode())
+                && expected.getName().equals(actual.getName())
+                && expected.getShortCont().equals(actual.getShortCont())
+                && expected.getLongCont().equals(actual.getLongCont())
+                && expected.getChkUse().equals(actual.getChkUse())
+                && expected.getOrd().equals(actual.getOrd())
+                && expected.getTermCondDate().equals(actual.getTermCondDate())
+                && expected.getTermCondUpDate().equals(actual.getTermCondUpDate())
+                && expected.getLaw1().equals(actual.getLaw1())
+                && expected.getLaw2().equals(actual.getLaw2())
+                && expected.getLaw3().equals(actual.getLaw3());
+
     }
 
     private void createDummy() {
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-001")
+                .name("서비스 이용약관")
+                .shortCont("서비스 이용에 관한 짧은 내용")
+                .longCont("서비스 이용에 관한 자세한 내용")
+                .chkUse('Y')
+                .ord(1)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("개인정보보호법")
+                .law2("전자상거래법")
+                .law3("소비자보호법")
+                .build());
 
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-002")
+                .name("개인정보 수집 및 이용")
+                .shortCont("개인정보 수집에 대한 짧은 설명")
+                .longCont("개인정보 수집 및 이용에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(2)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("정보통신망법")
+                .law2("개인정보보호법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-003")
+                .name("위치정보 이용 약관")
+                .shortCont("위치 정보 이용에 대한 짧은 설명")
+                .longCont("위치 정보 이용에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(3)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("위치정보법")
+                .law2("없음")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-004")
+                .name("쿠키 사용 약관")
+                .shortCont("쿠키 사용에 대한 짧은 설명")
+                .longCont("쿠키 사용에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(4)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("정보통신망법")
+                .law2("개인정보보호법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-005")
+                .name("마케팅 정보 수신 동의")
+                .shortCont("마케팅 정보 수신에 대한 짧은 설명")
+                .longCont("마케팅 정보 수신에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(5)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("개인정보보호법")
+                .law2("광고법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-006")
+                .name("제3자 제공 동의")
+                .shortCont("제3자 제공 동의에 대한 짧은 설명")
+                .longCont("제3자 제공 동의에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(6)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("개인정보보호법")
+                .law2("없음")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-007")
+                .name("구매 약관")
+                .shortCont("구매에 관한 짧은 설명")
+                .longCont("구매 약관에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(7)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("전자상거래법")
+                .law2("소비자보호법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-008")
+                .name("환불 약관")
+                .shortCont("환불 정책에 대한 짧은 설명")
+                .longCont("환불 약관에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(8)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("전자상거래법")
+                .law2("소비자보호법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-009")
+                .name("회원 탈퇴 약관")
+                .shortCont("회원 탈퇴 절차에 대한 짧은 설명")
+                .longCont("회원 탈퇴 절차에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(9)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("정보통신망법")
+                .law2("개인정보보호법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-010")
+                .name("서비스 변경 약관")
+                .shortCont("서비스 변경에 관한 짧은 설명")
+                .longCont("서비스 변경에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(10)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("전자상거래법")
+                .law2("소비자보호법")
+                .law3("정보통신망법")
+                .build());
     }
+
 }

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepositoryTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepositoryTest.java
@@ -70,8 +70,6 @@ class MemberTermConditionRepositoryTest {
                 && expected.getLongCont().equals(actual.getLongCont())
                 && expected.getChkUse().equals(actual.getChkUse())
                 && expected.getOrd().equals(actual.getOrd())
-                && expected.getTermCondDate().equals(actual.getTermCondDate())
-                && expected.getTermCondUpDate().equals(actual.getTermCondUpDate())
                 && expected.getLaw1().equals(actual.getLaw1())
                 && expected.getLaw2().equals(actual.getLaw2())
                 && expected.getLaw3().equals(actual.getLaw3());

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepositoryTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepositoryTest.java
@@ -1,0 +1,35 @@
+package com.oreo.finalproject_5re5_be.member.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application-test.properties")
+class MemberTermConditionRepositoryTest {
+
+    @Autowired
+    private MemberTermConditionRepository memberTermConditionRepository;
+
+    private List<MemberTermsCondition> dummy = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        assertNotNull(memberTermConditionRepository);
+        memberTermConditionRepository.deleteAll();
+
+        // 더미 생성
+
+        // 더미 저장
+    }
+
+    private void createDummy() {
+
+    }
+}

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/service/MemberServiceImplTest.java
@@ -24,7 +24,6 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
-@ExtendWith(MockitoExtension.class)
 @TestPropertySource(locations = "classpath:application-test.properties") // - 현재 에러가 발생함. h2와 MySQL의 pk 설정 차이
 class MemberServiceImplTest {
 
@@ -35,11 +34,6 @@ class MemberServiceImplTest {
     private JavaMailSender mailSender;
     @Autowired
     private MemberRepository memberRepository;
-    @Autowired
-    private MemberStateRepository memberStateRepository;
-    @Autowired
-    private MemberTermsHistoryRepository memberTermsHistoryRepository;
-
 
 
     @BeforeEach

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImplTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/service/MemberTermsConditionServiceImplTest.java
@@ -1,0 +1,407 @@
+package com.oreo.finalproject_5re5_be.member.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionRequest;
+import com.oreo.finalproject_5re5_be.member.dto.request.MemberTermConditionUpdateRequest;
+import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionResponse;
+import com.oreo.finalproject_5re5_be.member.dto.response.MemberTermConditionsResponse;
+import com.oreo.finalproject_5re5_be.member.entity.MemberTermsCondition;
+import com.oreo.finalproject_5re5_be.member.repository.MemberTermConditionRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application-test.properties")
+class MemberTermsConditionServiceImplTest {
+
+    @Autowired
+    private MemberTermsConditionServiceImpl memberTermsConditionService;
+
+    @Autowired
+    private MemberTermConditionRepository memberTermConditionRepository;
+
+    private List<MemberTermsCondition> dummy = new ArrayList<>();
+
+
+    @BeforeEach
+    void setUp() {
+        assertNotNull(memberTermsConditionService);
+        assertNotNull(memberTermConditionRepository);
+
+        // 초가화
+        dummy.clear();
+        memberTermConditionRepository.deleteAll();
+
+        // 더미 생성 및 저장
+        createDummy();
+        memberTermConditionRepository.saveAll(dummy);
+    }
+
+    @DisplayName("단건 회원 약관 항목을 등록함")
+    @Test
+    void 단건_회원_약관_항목을_등록함() {
+        // 기존에 등록된 더미 데이터 없애기
+        memberTermConditionRepository.deleteAll();
+        // 새로운 요청 더미 데이터 1개 생성
+        MemberTermConditionRequest request = MemberTermConditionRequest.builder()
+                .condCode("TC-001")
+                .name("서비스 이용약관")
+                .shortCont("서비스 이용에 관한 짧은 내용")
+                .longCont("서비스 이용에 관한 자세한 내용")
+                .chkUse('Y')
+                .ord(1)
+                .law1("개인정보보호법")
+                .law2("전자상거래법")
+                .law3("소비자보호법")
+                .build();
+        MemberTermsCondition expectedMemberTermCondition = MemberTermsCondition.builder()
+                .condCode("TC-001")
+                .name("서비스 이용약관")
+                .shortCont("서비스 이용에 관한 짧은 내용")
+                .longCont("서비스 이용에 관한 자세한 내용")
+                .chkUse('Y')
+                .ord(1)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("개인정보보호법")
+                .law2("전자상거래법")
+                .law3("소비자보호법")
+                .build();
+
+        // 서비스에 등록 요청
+        MemberTermConditionResponse expectedResponse = new MemberTermConditionResponse(expectedMemberTermCondition);
+        MemberTermConditionResponse response = memberTermsConditionService.create(request);
+
+        // 등록된 데이터와 요청한 데이터가 같은지 확인
+        assertTrue(isSameMemberTermConditionResponse(expectedResponse, response));
+    }
+
+    @DisplayName("여러개 회원 약관 항목을 등록함")
+    @Test
+    void 여러개_회원_약관_항목을_등록함() {
+        // 기존에 등록된 더미 데이터 없애기
+        memberTermConditionRepository.deleteAll();
+
+        // 새로운 요청 더미 데이터 여러개 생성
+        List<MemberTermConditionRequest> list = new ArrayList<>();
+        for (MemberTermsCondition memberTermsCondition : dummy) {
+            MemberTermConditionRequest request = MemberTermConditionRequest.builder()
+                    .condCode(memberTermsCondition.getCondCode())
+                    .name(memberTermsCondition.getName())
+                    .shortCont(memberTermsCondition.getShortCont())
+                    .longCont(memberTermsCondition.getLongCont())
+                    .chkUse(memberTermsCondition.getChkUse())
+                    .ord(memberTermsCondition.getOrd())
+                    .law1(memberTermsCondition.getLaw1())
+                    .law2(memberTermsCondition.getLaw2())
+                    .law3(memberTermsCondition.getLaw3())
+                    .build();
+            list.add(request);
+        }
+
+        // 서비스에 등록 요청
+        List<MemberTermConditionResponse> expectedCreatedDummy = new ArrayList<>();
+        for (MemberTermsCondition memberTermsCondition : dummy) {
+            MemberTermConditionResponse memberTermConditionResponse = new MemberTermConditionResponse(memberTermsCondition);
+            expectedCreatedDummy.add(memberTermConditionResponse);
+        }
+        MemberTermConditionsResponse expectedResponse = new MemberTermConditionsResponse(expectedCreatedDummy);
+        MemberTermConditionsResponse actualResponse = memberTermsConditionService.create(list);
+
+        // 등록된 데이터와 요청한 데이터가 같은지 확인
+        assertEquals(expectedResponse.getMemberTermConditionResponses().size(), actualResponse.getMemberTermConditionResponses().size());
+        for (int i = 0; i < expectedResponse.getMemberTermConditionResponses().size(); i++) {
+            assertTrue(isSameMemberTermConditionResponse(expectedResponse.getMemberTermConditionResponses().get(i), actualResponse.getMemberTermConditionResponses().get(i)));
+        }
+    }
+
+    @DisplayName("단건 회원 약관 항목을 조회함")
+    @Test
+    void 단건_회원_약관_항목을_조회함() {
+        // 기존에 등록된 회원 약관 항목 중 하나 조회
+        MemberTermsCondition selectedMemberTermsCondition = dummy.get(1);
+        MemberTermConditionResponse expectedMemberTermConditionResponse = new MemberTermConditionResponse(selectedMemberTermsCondition);
+
+        // 조회된 데이터와 기대하는 데이터가 같은지 확인
+        MemberTermConditionResponse foundMemberTermConditionResponse = memberTermsConditionService.read(selectedMemberTermsCondition.getCondCode());
+
+        assertTrue(isSameMemberTermConditionResponse(expectedMemberTermConditionResponse, foundMemberTermConditionResponse));
+    }
+
+    @DisplayName("모든 회원 약관 항목을 조회함")
+    @Test
+    void 여러개_회원_약관_항목을_조회함() {
+        // 기존에 등록된 회원 약관 항목 모두 조회
+        List<MemberTermConditionResponse> expectedMemberTermConditionResponses = new ArrayList<>();
+        for (MemberTermsCondition memberTermsCondition : dummy) {
+            MemberTermConditionResponse memberTermConditionResponse = new MemberTermConditionResponse(memberTermsCondition);
+            expectedMemberTermConditionResponses.add(memberTermConditionResponse);
+        }
+
+        MemberTermConditionsResponse foundMemberTermConditionsResponse = memberTermsConditionService.readAll();
+
+        // 조회된 데이터와 기대하는 데이터가 같은지 확인
+        assertEquals(expectedMemberTermConditionResponses.size(), foundMemberTermConditionsResponse.getMemberTermConditionResponses().size());
+        for (int i = 0; i < expectedMemberTermConditionResponses.size(); i++) {
+            assertTrue(isSameMemberTermConditionResponse(expectedMemberTermConditionResponses.get(i), foundMemberTermConditionsResponse.getMemberTermConditionResponses().get(i)));
+        }
+
+    }
+
+    @DisplayName("사용 가능한 회원 약관 항목을 조회함")
+    @Test
+    void 사용_가능한_회원_약관_항목을_조회함() {
+        // 기존에 등록된 회원 약관 항목 중 사용 가능한 항목만 조회
+        List<MemberTermsCondition> availableDummy = dummy.stream()
+                                                         .filter(m -> m.getChkUse().equals('Y'))
+                                                         .toList();
+        List<MemberTermConditionResponse> expectedMemberTermConditionResponses = new ArrayList<>();
+        for (MemberTermsCondition memberTermsCondition : availableDummy) {
+            MemberTermConditionResponse memberTermConditionResponse = new MemberTermConditionResponse(memberTermsCondition);
+            expectedMemberTermConditionResponses.add(memberTermConditionResponse);
+        }
+
+        // 조회된 데이터와 기대하는 데이터가 같은지 확인
+        MemberTermConditionsResponse foundMemberTermConditionsResponse = memberTermsConditionService.readAvailable();
+        assertEquals(expectedMemberTermConditionResponses.size(), foundMemberTermConditionsResponse.getMemberTermConditionResponses().size());
+        for (int i = 0; i < expectedMemberTermConditionResponses.size(); i++) {
+            assertTrue(isSameMemberTermConditionResponse(expectedMemberTermConditionResponses.get(i), foundMemberTermConditionsResponse.getMemberTermConditionResponses().get(i)));
+        }
+    }
+
+    @DisplayName("사용 불가능한 회원 약관 항목을 조회함")
+    @Test
+    void 사용_불가능한_회원_약관_항목을_조회함() {
+        // 기존에 등록된 회원 약관 항목 중 사용 불가능한 항목만 조회
+        List<MemberTermsCondition> notAvailableDummy = dummy.stream()
+                .filter(m -> m.getChkUse().equals('N'))
+                .toList();
+        List<MemberTermConditionResponse> expectedMemberTermConditionResponses = new ArrayList<>();
+        for (MemberTermsCondition memberTermsCondition : notAvailableDummy) {
+            MemberTermConditionResponse memberTermConditionResponse = new MemberTermConditionResponse(memberTermsCondition);
+            expectedMemberTermConditionResponses.add(memberTermConditionResponse);
+        }
+
+        // 조회된 데이터와 기대하는 데이터가 같은지 확인
+        MemberTermConditionsResponse foundMemberTermConditionsResponse = memberTermsConditionService.readNotAvailable();
+        assertEquals(expectedMemberTermConditionResponses.size(), foundMemberTermConditionsResponse.getMemberTermConditionResponses().size());
+        for (int i = 0; i < expectedMemberTermConditionResponses.size(); i++) {
+            assertTrue(isSameMemberTermConditionResponse(expectedMemberTermConditionResponses.get(i), foundMemberTermConditionsResponse.getMemberTermConditionResponses().get(i)));
+        }
+    }
+
+    @DisplayName("단건 회원 약관 항목을 수정함")
+    @Test
+    void 단건_회원_약관_항목을_수정함() {
+        // 기존에 등록된 회원 약관 항목 중 하나 조회
+        MemberTermsCondition selectedMemberTermsCondition = dummy.get(0);
+        MemberTermsCondition foundMemberTermsCondition = memberTermConditionRepository.findMemberTermsConditionByCondCode(
+                selectedMemberTermsCondition.getCondCode());
+        assertNotNull(foundMemberTermsCondition);
+
+        // 해당 항목의 시퀀스 조회
+        String termCondCode = foundMemberTermsCondition.getCondCode();
+
+        // 수정 요청 더미 데이터 생성
+        MemberTermConditionUpdateRequest request = MemberTermConditionUpdateRequest.builder()
+                .shortCont("업데이트된 서비스 이용에 관한 짧은 내용 수정")
+                .longCont("업데이트된 서비스 이용에 관한 자세한 내용 수정")
+                .chkUse('N')
+                .ord(10)
+                .build();
+
+        // 서비스에 수정 요청
+        memberTermsConditionService.update(termCondCode, request);
+
+        // 조회된 데이터와 기대하는 데이터가 같은지 확인
+        MemberTermsCondition updatedMemberTermCondition = memberTermConditionRepository.findMemberTermsConditionByCondCode(termCondCode);
+        assertEquals(request.getShortCont(), updatedMemberTermCondition.getShortCont());
+        assertEquals(request.getLongCont(), updatedMemberTermCondition.getLongCont());
+        assertEquals(request.getChkUse(), updatedMemberTermCondition.getChkUse());
+        assertEquals(request.getOrd(), updatedMemberTermCondition.getOrd());
+    }
+
+    @DisplayName("단건 회원 약관 항목을 삭제함")
+    @Test
+    void 단건_회원_약관_항목을_삭제함() {
+        // 기존에 등록된 회원 약관 항목 중 하나 조회
+        MemberTermsCondition selectedMemberTermsCondition = dummy.get(0);
+        MemberTermsCondition foundMemberTermsCondition = memberTermConditionRepository.findMemberTermsConditionByCondCode(
+                selectedMemberTermsCondition.getCondCode());
+        assertNotNull(foundMemberTermsCondition);
+
+        // 서비스에 삭제 요청
+        memberTermsConditionService.remove(selectedMemberTermsCondition.getCondCode());
+
+        // 조회된 데이터가 삭제되었는지 확인
+        foundMemberTermsCondition = memberTermConditionRepository.findMemberTermsConditionByCondCode(
+                selectedMemberTermsCondition.getCondCode());
+        assertNull(foundMemberTermsCondition);
+    }
+
+    private boolean isSameMemberTermConditionResponse(MemberTermConditionResponse memberTermConditionResponse1, MemberTermConditionResponse memberTermConditionResponse2) {
+        return memberTermConditionResponse1.getCondCode().equals(memberTermConditionResponse2.getCondCode())
+                && memberTermConditionResponse1.getShortCont().equals(memberTermConditionResponse2.getShortCont())
+                && memberTermConditionResponse1.getLongCont().equals(memberTermConditionResponse2.getLongCont())
+                && memberTermConditionResponse1.getChkUse().equals(memberTermConditionResponse2.getChkUse())
+                && memberTermConditionResponse1.getOrd().equals(memberTermConditionResponse2.getOrd())
+                && memberTermConditionResponse1.getLaw1().equals(memberTermConditionResponse2.getLaw1())
+                && memberTermConditionResponse1.getLaw2().equals(memberTermConditionResponse2.getLaw2())
+                && memberTermConditionResponse1.getLaw3().equals(memberTermConditionResponse2.getLaw3());
+
+    }
+
+
+    private void createDummy() {
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-001")
+                .name("서비스 이용약관")
+                .shortCont("서비스 이용에 관한 짧은 내용")
+                .longCont("서비스 이용에 관한 자세한 내용")
+                .chkUse('Y')
+                .ord(1)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("개인정보보호법")
+                .law2("전자상거래법")
+                .law3("소비자보호법")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-002")
+                .name("개인정보 수집 및 이용")
+                .shortCont("개인정보 수집에 대한 짧은 설명")
+                .longCont("개인정보 수집 및 이용에 대한 자세한 설명")
+                .chkUse('N')
+                .ord(2)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("정보통신망법")
+                .law2("개인정보보호법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-003")
+                .name("위치정보 이용 약관")
+                .shortCont("위치 정보 이용에 대한 짧은 설명")
+                .longCont("위치 정보 이용에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(3)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("위치정보법")
+                .law2("없음")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-004")
+                .name("쿠키 사용 약관")
+                .shortCont("쿠키 사용에 대한 짧은 설명")
+                .longCont("쿠키 사용에 대한 자세한 설명")
+                .chkUse('N')
+                .ord(4)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("정보통신망법")
+                .law2("개인정보보호법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-005")
+                .name("마케팅 정보 수신 동의")
+                .shortCont("마케팅 정보 수신에 대한 짧은 설명")
+                .longCont("마케팅 정보 수신에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(5)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("개인정보보호법")
+                .law2("광고법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-006")
+                .name("제3자 제공 동의")
+                .shortCont("제3자 제공 동의에 대한 짧은 설명")
+                .longCont("제3자 제공 동의에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(6)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("개인정보보호법")
+                .law2("없음")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-007")
+                .name("구매 약관")
+                .shortCont("구매에 관한 짧은 설명")
+                .longCont("구매 약관에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(7)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("전자상거래법")
+                .law2("소비자보호법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-008")
+                .name("환불 약관")
+                .shortCont("환불 정책에 대한 짧은 설명")
+                .longCont("환불 약관에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(8)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("전자상거래법")
+                .law2("소비자보호법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-009")
+                .name("회원 탈퇴 약관")
+                .shortCont("회원 탈퇴 절차에 대한 짧은 설명")
+                .longCont("회원 탈퇴 절차에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(9)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("정보통신망법")
+                .law2("개인정보보호법")
+                .law3("없음")
+                .build());
+
+        dummy.add(MemberTermsCondition.builder()
+                .condCode("TC-010")
+                .name("서비스 변경 약관")
+                .shortCont("서비스 변경에 관한 짧은 설명")
+                .longCont("서비스 변경에 대한 자세한 설명")
+                .chkUse('Y')
+                .ord(10)
+                .termCondDate(LocalDateTime.now())
+                .termCondUpDate(LocalDateTime.now())
+                .law1("전자상거래법")
+                .law2("소비자보호법")
+                .law3("정보통신망법")
+                .build());
+    }
+
+}


### PR DESCRIPTION
## 작업 내용
- 회원 약관 항목 개발 구현 했습니다.
- 컨트롤러, 서비스, 리포지토리 전부 구현
- 예외처리 핸들링 구현 

## 기타:
> 1. 참고 내용: 관리자 페이지 없다고 가정하고 개발하다 보니 코드 유지 보수성이 너무 안좋다고 생각해서. 그냥 관리자 페이지있다는 전제하에 컨트롤러, 서비스, 리포지토리 전부 구현했습니다.

- 컨트롤러 Mockito로 테스트 하실 때 서비스에서 응답되는 DTO에 equals()와 hashCode()가 모두 오버라이딩 되야합니다. 그렇지 않을 경우 테스트 코드에서 제대로 세팅해도 null 이 반환될 수 있습니다.