### PR TITLE
[feat] 통합 코드 테이블 기능 구현 

### DIFF
--- a/src/main/java/com/oreo/finalproject_5re5_be/member/controller/CodeController.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/controller/CodeController.java
@@ -1,0 +1,5 @@
+package com.oreo.finalproject_5re5_be.member.controller;
+
+public class CodeController {
+
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/controller/CodeController.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/controller/CodeController.java
@@ -1,5 +1,144 @@
 package com.oreo.finalproject_5re5_be.member.controller;
 
+import com.oreo.finalproject_5re5_be.global.dto.response.ErrorResponseDto;
+import com.oreo.finalproject_5re5_be.global.exception.ErrorCode;
+import com.oreo.finalproject_5re5_be.member.dto.request.CodeRequest;
+import com.oreo.finalproject_5re5_be.member.dto.request.CodeUpdateRequest;
+import com.oreo.finalproject_5re5_be.member.dto.response.CodeResponse;
+import com.oreo.finalproject_5re5_be.member.dto.response.CodeResponses;
+import com.oreo.finalproject_5re5_be.member.exception.CodeDuplicatedException;
+import com.oreo.finalproject_5re5_be.member.exception.CodeNotFoundException;
+import com.oreo.finalproject_5re5_be.member.service.CodeServiceImpl;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "CODE", description = "CODE 관련 API")
+@Validated
+@RestController
+@RequestMapping("/api/code")
 public class CodeController {
 
+    private final CodeServiceImpl codeService;
+
+    public CodeController(CodeServiceImpl codeService) {
+        this.codeService = codeService;
+    }
+
+    @ExceptionHandler({
+            CodeNotFoundException.class
+    })
+    public ResponseEntity<ErrorResponseDto> handleNotFoundException(RuntimeException e) {
+        log.error("[CodeNotFoundException]", e);
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.of(ErrorCode.INVALID_INPUT_VALUE.getStatus(),
+                                                                e.getMessage());
+        return ResponseEntity.status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                             .body(errorResponseDto);
+    }
+
+    @ExceptionHandler({
+            CodeDuplicatedException.class
+    })
+    public ResponseEntity<ErrorResponseDto> handleDuplicatedException(RuntimeException e) {
+        log.error("[CodeDuplicatedException]", e);
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.of(ErrorCode.ENTITY_NOT_FOUND.getStatus(),
+                                                                e.getMessage());
+
+        return ResponseEntity.status(ErrorCode.ENTITY_NOT_FOUND.getStatus()) // 상태코드가 중복해서 처리됨. 이 부분 이야기 해보기
+                             .body(errorResponseDto);
+    }
+
+    // 코드 등록
+    @PostMapping("/register")
+    public ResponseEntity<CodeResponse> create(@RequestBody @Valid CodeRequest request) {
+        // 서비스를 호출하여 코드를 등록한다
+        CodeResponse response = codeService.create(request);
+        // 등록된 코드를 반환한다
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(response);
+
+    }
+
+    // 모든 코드 조회
+    @GetMapping("/all")
+    public ResponseEntity<CodeResponses> readAll() {
+        // 서비스를 호출하여 모든 코드를 조회한다
+        CodeResponses responses = codeService.readAll();
+        // 조회된 코드를 반환한다
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(responses);
+    }
+
+    // 시퀀스로 특정 코드 조회
+    @GetMapping("/{codeSeq}")
+    public ResponseEntity<CodeResponse> read(@PathVariable Long codeSeq) {
+        // 서비스를 호출하여 시퀀스로 특정 코드를 조회한다
+        CodeResponse response = codeService.read(codeSeq);
+        // 조회된 코드를 반환한다
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(response);
+    }
+
+    // 코드 번호로 특정 코드 조회
+    @GetMapping("/{code}")
+    public ResponseEntity<CodeResponse> read(@PathVariable String code) {
+        // 서비스를 호출하여 코드 번호로 특정 코드를 조회한다
+        CodeResponse response = codeService.read(code);
+        // 조회된 코드를 반환한다
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(response);
+    }
+
+    // 각 파트(cateNum)으로 사용 가능한 코드 조회
+    @GetMapping("/{cateNum}/available")
+    public ResponseEntity<CodeResponses> readAvailable(@PathVariable String cateNum) {
+        // 서비스를 호출하여 각 파트별 사용 가능한 코드를 조회한다
+        CodeResponses responses = codeService.readAvailableCodeByCateNum(cateNum);
+        // 조회된 코드를 반환한다
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(responses);
+    }
+
+    // 각 파트(cateNum)으로 모든 코드 조회
+    @GetMapping("/{cateNum}/all")
+    public ResponseEntity<CodeResponses> readAll(@PathVariable String cateNum) {
+        // 서비스를 호출하여 각 파트별 모든 코드를 조회한다
+        CodeResponses responses = codeService.readAllByCateNum(cateNum);
+        // 조회된 코드를 반환한다
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(responses);
+    }
+
+    // 코드 수정
+    @PatchMapping("/{codeSeq}")
+    public ResponseEntity<Void> update(@PathVariable Long codeSeq, @Valid @RequestBody CodeUpdateRequest request) {
+        // 서비스를 호출하여 코드를 수정한다
+        codeService.update(codeSeq, request);
+        // 수정된 코드를 반환한다
+        return ResponseEntity.status(HttpStatus.OK)
+                             .build();
+    }
+
+    // 코드 삭제
+    @DeleteMapping("/{codeSeq}")
+    public ResponseEntity<Void> delete(@PathVariable Long codeSeq) {
+        // 서비스를 호출하여 코드를 삭제한다
+        codeService.delete(codeSeq);
+        // 삭제된 코드를 반환한다
+        return ResponseEntity.status(HttpStatus.OK)
+                             .build();
+    }
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/controller/CodeController.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/controller/CodeController.java
@@ -34,6 +34,7 @@ public class CodeController {
 
     private final CodeServiceImpl codeService;
 
+
     public CodeController(CodeServiceImpl codeService) {
         this.codeService = codeService;
     }
@@ -83,8 +84,8 @@ public class CodeController {
     }
 
     // 시퀀스로 특정 코드 조회
-    @GetMapping("/{codeSeq}")
-    public ResponseEntity<CodeResponse> read(@PathVariable Long codeSeq) {
+    @GetMapping("/seq/{codeSeq}")
+    public ResponseEntity<CodeResponse> readBySeq(@PathVariable Long codeSeq) {
         // 서비스를 호출하여 시퀀스로 특정 코드를 조회한다
         CodeResponse response = codeService.read(codeSeq);
         // 조회된 코드를 반환한다
@@ -94,7 +95,7 @@ public class CodeController {
 
     // 코드 번호로 특정 코드 조회
     @GetMapping("/{code}")
-    public ResponseEntity<CodeResponse> read(@PathVariable String code) {
+    public ResponseEntity<CodeResponse> readByCode(@PathVariable String code) {
         // 서비스를 호출하여 코드 번호로 특정 코드를 조회한다
         CodeResponse response = codeService.read(code);
         // 조회된 코드를 반환한다
@@ -128,7 +129,7 @@ public class CodeController {
         // 서비스를 호출하여 코드를 수정한다
         codeService.update(codeSeq, request);
         // 수정된 코드를 반환한다
-        return ResponseEntity.status(HttpStatus.OK)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
                              .build();
     }
 
@@ -138,7 +139,7 @@ public class CodeController {
         // 서비스를 호출하여 코드를 삭제한다
         codeService.delete(codeSeq);
         // 삭제된 코드를 반환한다
-        return ResponseEntity.status(HttpStatus.OK)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
                              .build();
     }
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/CodeRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/CodeRequest.java
@@ -1,0 +1,40 @@
+package com.oreo.finalproject_5re5_be.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@EqualsAndHashCode
+public class CodeRequest {
+
+    @NotBlank(message = "코드 번호를 입력해주세요.")
+    @Pattern(regexp = "^[a-zA-Z0-9]{1,10}$", message = "코드 번호는 1~10자의 영문 및 숫자만 허용됩니다.")
+    private String cateNum;
+
+    @NotBlank(message = "코드를 입력해주세요.")
+    @Pattern(regexp = "^[a-zA-Z0-9]{1,20}$", message = "약관 코드는 1~20자의 영문 및 숫자만 허용됩니다.")
+    private String code;
+
+    @NotBlank(message = "코드명을 입력해주세요.")
+    private String name;
+
+    @NotBlank(message = "순서를 입력해주세요.")
+    private Integer ord;
+
+    @NotBlank(message = "사용여부를 입력해주세요.")
+    private String chkUse;
+
+    private String comt;
+
+
+
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/CodeRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/CodeRequest.java
@@ -1,5 +1,6 @@
 package com.oreo.finalproject_5re5_be.member.dto.request;
 
+import com.oreo.finalproject_5re5_be.member.entity.Code;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
@@ -36,5 +37,15 @@ public class CodeRequest {
     private String comt;
 
 
+    public Code createCodeEntity() {
+        return Code.builder()
+                .cateNum(cateNum)
+                .code(code)
+                .name(name)
+                .ord(ord)
+                .chkUse(chkUse)
+                .comt(comt)
+                .build();
+    }
 
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/CodeRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/CodeRequest.java
@@ -2,6 +2,7 @@ package com.oreo.finalproject_5re5_be.member.dto.request;
 
 import com.oreo.finalproject_5re5_be.member.entity.Code;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -28,7 +29,7 @@ public class CodeRequest {
     @NotBlank(message = "코드명을 입력해주세요.")
     private String name;
 
-    @NotBlank(message = "순서를 입력해주세요.")
+    @NotNull(message = "코드 정렬 순서를 입력해주세요.")
     private Integer ord;
 
     @NotBlank(message = "사용여부를 입력해주세요.")

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/CodeUpdateRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/CodeUpdateRequest.java
@@ -2,6 +2,7 @@ package com.oreo.finalproject_5re5_be.member.dto.request;
 
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -18,7 +19,7 @@ public class CodeUpdateRequest {
     @NotBlank(message = "코드명을 입력해주세요.")
     private String name;
 
-    @NotBlank(message = "순서를 입력해주세요.")
+    @NotNull(message = "정렬 순서를 입력해주세요.")
     private Integer ord;
 
     @NotBlank(message = "사용여부를 입력해주세요.")

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/CodeUpdateRequest.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/request/CodeUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.oreo.finalproject_5re5_be.member.dto.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@EqualsAndHashCode
+public class CodeUpdateRequest {
+
+    @NotBlank(message = "코드명을 입력해주세요.")
+    private String name;
+
+    @NotBlank(message = "순서를 입력해주세요.")
+    private Integer ord;
+
+    @NotBlank(message = "사용여부를 입력해주세요.")
+    private String chkUse;
+
+    private String comt;
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/CodeResponse.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/CodeResponse.java
@@ -1,0 +1,21 @@
+package com.oreo.finalproject_5re5_be.member.dto.response;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+
+@Getter
+@ToString
+@NoArgsConstructor
+@EqualsAndHashCode
+public class CodeResponse {
+    private Long codeSeq;
+    private String cateNum;
+    private String code;
+    private String name;
+    private Integer ord;
+    private String chkUse;
+    private String comt;
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/CodeResponse.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/CodeResponse.java
@@ -1,5 +1,7 @@
 package com.oreo.finalproject_5re5_be.member.dto.response;
 
+import com.oreo.finalproject_5re5_be.member.entity.Code;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +10,7 @@ import lombok.ToString;
 
 @Getter
 @ToString
-@NoArgsConstructor
+@Builder
 @EqualsAndHashCode
 public class CodeResponse {
     private Long codeSeq;
@@ -18,4 +20,16 @@ public class CodeResponse {
     private Integer ord;
     private String chkUse;
     private String comt;
+
+    public static CodeResponse of(Code code) {
+        return CodeResponse.builder()
+                .codeSeq(code.getCodeSeq())
+                .cateNum(code.getCateNum())
+                .code(code.getCode())
+                .name(code.getName())
+                .ord(code.getOrd())
+                .chkUse(code.getChkUse())
+                .comt(code.getComt())
+                .build();
+    }
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/CodeResponses.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/CodeResponses.java
@@ -1,0 +1,25 @@
+package com.oreo.finalproject_5re5_be.member.dto.response;
+
+
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@EqualsAndHashCode
+public class CodeResponses {
+
+    private List<CodeResponse> codeResponses;
+
+    public CodeResponses(List<CodeResponse> codeResponses) {
+        this.codeResponses = codeResponses;
+    }
+
+    public static CodeResponses of(List<CodeResponse> codeResponses) {
+        return new CodeResponses(codeResponses);
+    }
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberReadResponse.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/dto/response/MemberReadResponse.java
@@ -7,7 +7,6 @@ import lombok.Setter;
 import lombok.ToString;
 
 @Getter
-@Setter
 @Builder
 @ToString
 @EqualsAndHashCode

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/Code.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/Code.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -24,6 +25,7 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = false)
 @Builder
 public class Code extends BaseEntity {
     @Id

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/Code.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/Code.java
@@ -1,6 +1,7 @@
 package com.oreo.finalproject_5re5_be.member.entity;
 
 import com.oreo.finalproject_5re5_be.global.entity.BaseEntity;
+import com.oreo.finalproject_5re5_be.member.dto.request.CodeUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -47,6 +48,13 @@ public class Code extends BaseEntity {
 
     @Column(name = "comt", length = 250)
     private String comt;
+
+    public void update(CodeUpdateRequest request) {
+        this.name = request.getName();
+        this.ord = request.getOrd();
+        this.chkUse = request.getChkUse();
+        this.comt = request.getComt();
+    }
 
 }
 

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/Code.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/Code.java
@@ -48,18 +48,5 @@ public class Code extends BaseEntity {
     @Column(name = "comt", length = 250)
     private String comt;
 
-    @Column(name = "reg_date")
-    private LocalDateTime regDate;
-
-    @Column(name = "reg_id", length = 20)
-    private String regId;
-
-    @Column(name = "up_date")
-    private LocalDateTime upDate;
-
-    @Column(name = "up_id", length = 20)
-    private String upId;
-
-
 }
 

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/entity/Code.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/entity/Code.java
@@ -1,0 +1,65 @@
+package com.oreo.finalproject_5re5_be.member.entity;
+
+import com.oreo.finalproject_5re5_be.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Table(name = "code")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Code extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "code_seq", nullable = false)
+    private Long codeSeq;
+
+    @Column(name = "cate_num", nullable = false, length = 30)
+    private String cateNum;
+
+    @Column(name = "code", nullable = false, length = 30)
+    private String code;
+
+    @Column(name = "name", length = 30)
+    private String name;
+
+    @Column(name = "ord")
+    private Integer ord;
+
+    @Column(name = "chk_use", length = 1, columnDefinition = "char(1) default 'Y'")
+    private String chkUse;
+
+    @Column(name = "comt", length = 250)
+    private String comt;
+
+    @Column(name = "reg_date")
+    private LocalDateTime regDate;
+
+    @Column(name = "reg_id", length = 20)
+    private String regId;
+
+    @Column(name = "up_date")
+    private LocalDateTime upDate;
+
+    @Column(name = "up_id", length = 20)
+    private String upId;
+
+
+}
+

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/exception/CodeDuplicatedException.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/exception/CodeDuplicatedException.java
@@ -1,0 +1,13 @@
+package com.oreo.finalproject_5re5_be.member.exception;
+
+public class CodeDuplicatedException extends RuntimeException {
+
+    public CodeDuplicatedException(String message) {
+        super(message);
+    }
+
+    public CodeDuplicatedException() {
+        this("중복된 코드명입니다.");
+    }
+
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/exception/CodeNotFoundException.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/exception/CodeNotFoundException.java
@@ -1,0 +1,13 @@
+package com.oreo.finalproject_5re5_be.member.exception;
+
+public class CodeNotFoundException extends RuntimeException {
+
+    public CodeNotFoundException(String message) {
+        super(message);
+    }
+
+    public CodeNotFoundException() {
+        this("코드를 찾을 수 없습니다.");
+    }
+
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/repository/CodeRepository.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/repository/CodeRepository.java
@@ -1,0 +1,27 @@
+package com.oreo.finalproject_5re5_be.member.repository;
+
+import com.oreo.finalproject_5re5_be.member.entity.Code;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface CodeRepository extends JpaRepository<Code, Long> {
+
+    // 코드 번호로 특정 코드를 조회합니다.
+    public Code findCodeByCode(String code);
+
+    // 각 파트별로 사용 가능한 코드를 조회합니다.
+    @Query( "SELECT c " +
+            "FROM Code c " +
+            "WHERE c.cateNum = :cateNum " +
+            "AND c.chkUse = 'Y' " +
+            "ORDER BY c.ord")
+    public List<Code> findAvailableCodesByCateNum(String cateNum);
+
+    // 각 파트별로 모든 코드를 조회합니다.
+    @Query( "SELECT c " +
+            "FROM Code c " +
+            "WHERE c.cateNum = :cateNum " +
+            "ORDER BY c.ord")
+    public List<Code> findCodesByCateNum(String cateNum);
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/repository/CodeRepository.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/repository/CodeRepository.java
@@ -7,21 +7,30 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface CodeRepository extends JpaRepository<Code, Long> {
 
-    // 코드 번호로 특정 코드를 조회합니다.
-    public Code findCodeByCode(String code);
+    // 코드 번호로 특정 코드를 조회.
+    Code findCodeByCode(String code);
 
-    // 각 파트별로 사용 가능한 코드를 조회합니다.
+    // 코드 시퀀스로 특정 코드를 조회.
+    Code findCodeByCodeSeq(Long codeSeq);
+
+    // 각 파트별로 사용 가능한 코드를 조회.
     @Query( "SELECT c " +
             "FROM Code c " +
             "WHERE c.cateNum = :cateNum " +
             "AND c.chkUse = 'Y' " +
             "ORDER BY c.ord")
-    public List<Code> findAvailableCodesByCateNum(String cateNum);
+    List<Code> findAvailableCodesByCateNum(String cateNum);
 
-    // 각 파트별로 모든 코드를 조회합니다.
+    // 각 파트별로 모든 코드를 조회.
     @Query( "SELECT c " +
             "FROM Code c " +
             "WHERE c.cateNum = :cateNum " +
             "ORDER BY c.ord")
-    public List<Code> findCodesByCateNum(String cateNum);
+    List<Code> findCodesByCateNum(String cateNum);
+
+    // 코드 번호로 코드가 존재하는지 확인.
+    boolean existsByCode(String code);
+
+    //
+    boolean existsByCodeSeq(Long codeSeq);
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepository.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/repository/MemberTermConditionRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface MemberTermConditionRepository extends JpaRepository<MemberTermsCondition, Long> {
 
     MemberTermsCondition findMemberTermsConditionByCondCode(String condCode);

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImpl.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImpl.java
@@ -1,7 +1,15 @@
 package com.oreo.finalproject_5re5_be.member.service;
 
 
+import com.oreo.finalproject_5re5_be.member.dto.request.CodeRequest;
+import com.oreo.finalproject_5re5_be.member.dto.request.CodeUpdateRequest;
+import com.oreo.finalproject_5re5_be.member.dto.response.CodeResponse;
+import com.oreo.finalproject_5re5_be.member.dto.response.CodeResponses;
+import com.oreo.finalproject_5re5_be.member.entity.Code;
+import com.oreo.finalproject_5re5_be.member.exception.CodeDuplicatedException;
+import com.oreo.finalproject_5re5_be.member.exception.CodeNotFoundException;
 import com.oreo.finalproject_5re5_be.member.repository.CodeRepository;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,11 +24,105 @@ public class CodeServiceImpl {
     }
 
     // 코드 등록
+    public CodeResponse create(CodeRequest request) {
+        // 유효성 검증이 완료된 request로부터 엔티티를 생성한다
+        // 기존에 코드와 중복되는지 확인한다
+        boolean isDuplicated = codeRepository.existsByCode(request.getCode());
+        if (isDuplicated) {
+            throw new CodeDuplicatedException();
+        }
+
+        // 중복되는 코드가 없다면 저장한다
+        Code code = request.createCodeEntity();
+        Code savedCode = codeRepository.save(code);
+        return CodeResponse.of(savedCode);
+    }
 
     // 코드 조회
 
+    // 모든 코드 조회
+    public CodeResponses readAll() {
+        // 모든 코드 엔티티를 조회
+        List<Code> foundCodes = codeRepository.findAll();
+        // 리스트로 변환
+        List<CodeResponse> codeResponseList = foundCodes.stream()
+                                                     .map(CodeResponse::of)
+                                                     .toList();
+
+        // 조회된 엔티티를 response로 변환하여 반환한다
+        return CodeResponses.of(codeResponseList);
+    }
+
+    // 시퀀스로 조회
+    public CodeResponse read(Long codeSeq) {
+        // 시퀀스로 특정 코드 엔티티를 조회한다
+        Code foundCode = codeRepository.findCodeByCodeSeq(codeSeq);
+        // 조회된 엔티티를 response로 변환하여 반환한다
+        return CodeResponse.of(foundCode);
+    }
+
+    // 코드 번호로 특정 코드 조회
+    public CodeResponse read(String code) {
+        // 코드 번호로 특정 코드 엔티티를 조회한다
+        Code foundCode = codeRepository.findCodeByCode(code);
+        // 조회된 엔티티를 response로 변환하여 반환한다
+        return CodeResponse.of(foundCode);
+    }
+
+
+    // 각 파트별 사용 가능한 코드 조회
+    public CodeResponses readAvailableCodeByCateNum(String cateNum) {
+        // 전달 받은 파트에 해당하는 사용 가능한 모든 코드 엔티티를 조회한다
+        List<Code> foundCodes = codeRepository.findAvailableCodesByCateNum(cateNum);
+        // 리스트에 담는다
+        List<CodeResponse> codeResponseList = foundCodes.stream()
+                                                        .map(CodeResponse::of)
+                                                        .toList();
+        // 조회된 엔티티를 responses로 변환하여 반환한다
+        return CodeResponses.of(codeResponseList);
+    }
+
+    // 각 파트별 모든 코드 조회
+    public CodeResponses readAllCodeByPart(String cateNum) {
+        // 전달 받은 파트에 해당하는 모든 코드 엔티티를 조회한다
+        List<Code> foundCodes = codeRepository.findCodesByCateNum(cateNum);
+        // 리스트에 담는다
+        List<CodeResponse> codeResponseList = foundCodes.stream()
+                .map(CodeResponse::of)
+                .toList();
+        // 조회된 엔티티를 responses로 변환하여 반환한다
+        return CodeResponses.of(codeResponseList);
+    }
+
+
     // 코드 수정
+    public void update(Long codeSeq, CodeUpdateRequest request) {
+        // 시퀀스로 특정 코드 엔티티를 조회한다
+        Code foundCode = codeRepository.findCodeByCodeSeq(codeSeq);
+
+        // 조회에 실패할 경우 예외를 발생시킨다.
+        if (foundCode == null) {
+            // 없을 경우 예외 발생
+            throw new CodeNotFoundException();
+        }
+
+        // 유효성 검증이 완료된 request로부터 엔티티를 수정한다
+        foundCode.update(request);
+    }
 
     // 코드 삭제
+    public void delete(Long codeSeq) {
+        // 시퀀스로 특정 코드 엔티티를 조회한다
+        Code foundCode = codeRepository.findCodeByCodeSeq(codeSeq);
+
+        // 조회에 실패할 경우 예외를 발생시킨다.
+        if (foundCode == null) {
+            // 없을 경우 예외 발생
+            throw new CodeNotFoundException();
+        }
+
+        // 조회된 엔티티를 삭제한다
+        codeRepository.delete(foundCode);
+    }
 
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImpl.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImpl.java
@@ -1,5 +1,26 @@
 package com.oreo.finalproject_5re5_be.member.service;
 
+
+import com.oreo.finalproject_5re5_be.member.repository.CodeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
 public class CodeServiceImpl {
+
+    private final CodeRepository codeRepository;
+
+    public CodeServiceImpl(CodeRepository codeRepository) {
+        this.codeRepository = codeRepository;
+    }
+
+    // 코드 등록
+
+    // 코드 조회
+
+    // 코드 수정
+
+    // 코드 삭제
 
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImpl.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImpl.java
@@ -1,0 +1,5 @@
+package com.oreo.finalproject_5re5_be.member.service;
+
+public class CodeServiceImpl {
+
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImpl.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImpl.java
@@ -83,7 +83,7 @@ public class CodeServiceImpl {
     }
 
     // 각 파트별 모든 코드 조회
-    public CodeResponses readAllCodeByPart(String cateNum) {
+    public CodeResponses readAllByCateNum(String cateNum) {
         // 전달 받은 파트에 해당하는 모든 코드 엔티티를 조회한다
         List<Code> foundCodes = codeRepository.findCodesByCateNum(cateNum);
         // 리스트에 담는다

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/controller/CodeControllerTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/controller/CodeControllerTest.java
@@ -1,0 +1,291 @@
+package com.oreo.finalproject_5re5_be.member.controller;
+
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oreo.finalproject_5re5_be.member.dto.request.CodeRequest;
+import com.oreo.finalproject_5re5_be.member.dto.request.CodeUpdateRequest;
+import com.oreo.finalproject_5re5_be.member.dto.response.CodeResponse;
+import com.oreo.finalproject_5re5_be.member.dto.response.CodeResponses;
+import com.oreo.finalproject_5re5_be.member.service.CodeServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+@WebMvcTest(CodeController.class)
+class CodeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CodeServiceImpl codeService;
+
+    private CodeRequest request;
+    private CodeUpdateRequest updateRequest;
+    private CodeResponse response;
+    private CodeResponses responses;
+
+
+    @BeforeEach
+    void setUp() {
+        // 자동 주입 확인
+        assertNotNull(codeService);
+        assertNotNull(mockMvc);
+        assertNotNull(objectMapper);
+
+        // 더미 데이터 생성
+        createCodeRequest();
+        createCodeUpdateRequest();
+        createCodeResponse();
+        createCodeResponses();
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("코드 등록 처리")
+    void 코드_등록_처리() throws Exception {
+        // 더미 데이터 생성
+
+        // 서비스 목킹
+        // - 서비스 생성 메서드 호출시 response 데이터 반환하도록 설정
+        when(codeService.create(request)).thenReturn(response);
+
+        // 컨트롤러 요청 보내기 및 결과 비교
+        mockMvc.perform(post("/api/code/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf())
+                )
+               .andExpect(status().isCreated())
+               .andExpect(jsonPath("$.cateNum").value(response.getCateNum()))
+               .andExpect(jsonPath("$.code").value(response.getCode()))
+               .andExpect(jsonPath("$.name").value(response.getName()))
+               .andExpect(jsonPath("$.ord").value(response.getOrd()));
+
+    }
+
+
+    @Test
+    @WithMockUser
+    @DisplayName("모든 코드 조회 처리")
+    void 모든_코드_조회_처리() throws Exception {
+        // 더미 데이터 생성
+
+        // 서비스 목킹
+        // - 서비스 모든 코드 조회 메서드 호출시 responses 데이터 반환하도록 설정
+        when(codeService.readAll()).thenReturn(responses);
+
+        // 컨트롤러 요청 보내기 및 결과 비교
+        mockMvc.perform(get("/api/code/all"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.codeResponses[0].cateNum").value(responses.getCodeResponses().get(0).getCateNum()))
+               .andExpect(jsonPath("$.codeResponses[0].code").value(responses.getCodeResponses().get(0).getCode()))
+               .andExpect(jsonPath("$.codeResponses[0].name").value(responses.getCodeResponses().get(0).getName()))
+               .andExpect(jsonPath("$.codeResponses[0].ord").value(responses.getCodeResponses().get(0).getOrd()));
+
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("시퀀스로 특정 코드 조회")
+    void 시퀀스로_특정_코드_조회() throws Exception {
+        // 더미 데이터 생성
+
+        // 서비스 목킹
+        // - 서비스 시퀀스로 조회 메서드 호출시 response 데이터 반환하도록 설정
+        when(codeService.read(1L)).thenReturn(response);
+
+        // 컨트롤러 요청 보내기 및 결과 비교
+        mockMvc.perform(get("/api/code/seq/1"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.cateNum").value(response.getCateNum()))
+               .andExpect(jsonPath("$.code").value(response.getCode()))
+               .andExpect(jsonPath("$.name").value(response.getName()))
+               .andExpect(jsonPath("$.ord").value(response.getOrd()));
+
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("코드 번호로 특정 코드 조회")
+    void 코드_번호로_특정_코드_조회() throws Exception {
+        // 더미 데이터 생성
+        String code = request.getCode();
+
+        // 서비스 목킹
+        // - 서비스 코드 번호로 조회 메서드 호출시 response 데이터 반환하도록 설정
+        when(codeService.read(code)).thenReturn(response);
+
+        // 컨트롤러 요청 보내기 및 결과 비교
+        mockMvc.perform(get("/api/code/" + code))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cateNum").value(response.getCateNum()))
+                .andExpect(jsonPath("$.code").value(response.getCode()))
+                .andExpect(jsonPath("$.name").value(response.getName()))
+                .andExpect(jsonPath("$.ord").value(response.getOrd()));
+
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("각 파트(cateNum)으로 사용 가능한 코드 조회")
+    void 각_파트_cateNum_으로_사용_가능한_코드_조회() throws Exception {
+        // 더미 데이터 생성
+
+        // 서비스 목킹
+        // - 서비스 각 파트별 사용 가능한 코드 조회 메서드 호출시 responses 데이터 반환하도록 설정
+        when(codeService.readAvailableCodeByCateNum("MB")).thenReturn(responses);
+
+        // 컨트롤러 요청 보내기 및 결과 비교
+        mockMvc.perform(get("/api/code/MB/available"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.codeResponses[0].cateNum").value(responses.getCodeResponses().get(0).getCateNum()))
+               .andExpect(jsonPath("$.codeResponses[0].code").value(responses.getCodeResponses().get(0).getCode()))
+               .andExpect(jsonPath("$.codeResponses[0].name").value(responses.getCodeResponses().get(0).getName()))
+               .andExpect(jsonPath("$.codeResponses[0].ord").value(responses.getCodeResponses().get(0).getOrd()));
+
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("각 파트(cateNum)으로 모든 코드 조회")
+    void 각_파트_cateNum_으로_모든_코드_조회() throws Exception {
+        // 더미 데이터 생성
+
+        // 서비스 목킹
+        // - 서비스 각 파트별 모든 코드 조회 메서드 호출시 responses 데이터 반환하도록 설정
+        when(codeService.readAllByCateNum("MB")).thenReturn(responses);
+
+        // 컨트롤러 요청 보내기 및 결과 비교
+        mockMvc.perform(get("/api/code/MB/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.codeResponses[0].cateNum").value(responses.getCodeResponses().get(0).getCateNum()))
+                .andExpect(jsonPath("$.codeResponses[0].code").value(responses.getCodeResponses().get(0).getCode()))
+                .andExpect(jsonPath("$.codeResponses[0].name").value(responses.getCodeResponses().get(0).getName()))
+                .andExpect(jsonPath("$.codeResponses[0].ord").value(responses.getCodeResponses().get(0).getOrd()));
+
+
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("코드 수정")
+    void 코드_수정() throws Exception {
+        // 더미 데이터 생성
+
+        // 서비스 목킹
+        // - 서비스 시퀀스와 updateRequest 데이터로 update 메서드 호출시 목킹
+        doNothing().when(codeService).update(1L, updateRequest);
+
+        // 컨트롤러 요청 보내기 및 결과 비교
+        mockMvc.perform(patch("/api/code/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest))
+                        .with(csrf())
+                )
+               .andExpect(status().isNoContent());
+    }
+
+
+    @Test
+    @WithMockUser
+    @DisplayName("코드 삭제 처리")
+    void 코드_수정_실패() throws Exception {
+        // 더미 데이터 생성
+
+        // 서비스 목킹
+        // - 서비스 시퀀스로 삭제 목킹
+        doNothing().when(codeService).delete(1L);
+
+        // 컨트롤러 요청 보내기 및 결과 비교
+        mockMvc.perform(delete("/api/code/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest))
+                        .with(csrf())
+                )
+               .andExpect(status().isNoContent());
+
+    }
+
+    private void createCodeRequest() {
+        request = CodeRequest.builder()
+                             .cateNum("MB")
+                             .code("MBS01")
+                             .name("신규회원")
+                             .ord(1)
+                             .chkUse("Y")
+                             .build();
+    }
+
+    private void createCodeUpdateRequest() {
+        updateRequest = CodeUpdateRequest.builder()
+                                         .name("변경된 신규회원")
+                                         .ord(1)
+                                         .chkUse("Y")
+                                         .build();
+    }
+
+    private void createCodeResponse() {
+        response = CodeResponse.builder()
+                               .cateNum("MB")
+                               .code("MBS01")
+                               .name("신규회원")
+                               .ord(1)
+                               .chkUse("Y")
+                               .build();
+    }
+
+    private void createCodeResponses() {
+        List<CodeResponse> dummy = new ArrayList<>();
+
+        dummy.add(CodeResponse.builder()
+                              .cateNum("MB")
+                              .code("MBS01")
+                              .name("신규회원")
+                              .ord(1)
+                              .chkUse("Y")
+                              .build());
+
+        dummy.add(CodeResponse.builder()
+                                .cateNum("MB")
+                                .code("MBS02")
+                                .name("기존회원")
+                                .ord(2)
+                                .build());
+
+
+        dummy.add(CodeResponse.builder()
+                                .cateNum("MB")
+                                .code("MBS03")
+                                .name("탈퇴회원")
+                                .ord(3)
+                                .chkUse("N")
+                                .build());
+
+
+        responses = new CodeResponses(dummy);
+    }
+}

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/controller/MemberControllerTest.java
@@ -21,16 +21,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(MemberController.class)

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/repository/CodeRepositoryTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/repository/CodeRepositoryTest.java
@@ -1,0 +1,130 @@
+package com.oreo.finalproject_5re5_be.member.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.oreo.finalproject_5re5_be.member.entity.Code;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application-test.properties")
+class CodeRepositoryTest {
+
+
+    @Autowired
+    private CodeRepository codeRepository;
+
+    private List<Code> dummy = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        // 자동주입 확인
+        assertNotNull(codeRepository);
+
+        // 초기화
+        codeRepository.deleteAll();
+
+        // 더미 데이터 생성 및 저장
+        createDummy();
+        codeRepository.saveAll(dummy);
+
+        // 더미 데이터 정렬시키기
+        dummy.sort((c1, c2) -> c1.getOrd().compareTo(c2.getOrd()));
+    }
+
+    @DisplayName("코드 번호로 특정 코드 조회")
+    @Test
+    void 코드_번호_특정_코드_조회() {
+        // 더미 데이터 생성 및 저장
+        // 해당 데이터 코드 번호로 조회
+        Code foundCode = codeRepository.findCodeByCode("MS001");
+        Code expectedCode = dummy.get(0);
+
+        // 결과 동일한지 비교
+        assertTrue(isSameCode(expectedCode, foundCode));
+
+    }
+
+    @DisplayName("각 파트별 사용 가능한 코드 조회")
+    @Test
+    void 각_파트별_사용_가능한_코드_조회() {
+        // 회원 파트 여러 더미 데이터 생성 및 저장
+        // 해당 파트의 사용 가능한 코드 조회
+        List<Code> foundCodes = codeRepository.findAvailableCodesByCateNum("M");
+        List<Code> expectedCodes = dummy.stream()
+                                        .filter(c -> c.getCateNum().equals("M") && c.getChkUse().equals("Y"))
+                                        .toList();
+
+        // 결과 동일한지 비교
+        assertTrue(foundCodes.size() == expectedCodes.size());
+        for (int i = 0; i < foundCodes.size(); i++) {
+            assertTrue(isSameCode(expectedCodes.get(i), foundCodes.get(i)));
+        }
+
+    }
+
+    @DisplayName("각 파트별 모든 코드 조회")
+    @Test
+    void 각_파트별_모든_코드_조회() {
+        // 회원 파트 여러 더미 데이터 생성 및 저장
+        // 해당 파트의 모든 코드 조회
+        List<Code> foundCodes = codeRepository.findCodesByCateNum("M");
+
+        // 결과 동일한지 비교
+        assertTrue(foundCodes.size() == dummy.size());
+
+
+        for (int i = 0; i < foundCodes.size(); i++) {
+            assertTrue(isSameCode(dummy.get(i), foundCodes.get(i)));
+        }
+
+    }
+
+    private void createDummy() {
+        // 더미 데이터 생성
+        Code code1 = Code.builder()
+                .code("MS001")
+                .cateNum("M")
+                .name("신규회원")
+                .chkUse("Y")
+                .ord(1)
+                .build();
+
+        Code code2 = Code.builder()
+                .code("MS002")
+                .cateNum("M")
+                .name("VIP회원")
+                .chkUse("N")
+                .ord(2)
+                .build();
+
+        Code code3 = Code.builder()
+                .code("MS003")
+                .cateNum("M")
+                .name("비활성회원")
+                .chkUse("Y")
+                .ord(3)
+                .build();
+
+        dummy.add(code1);
+        dummy.add(code2);
+        dummy.add(code3);
+    }
+
+    private boolean isSameCode(Code expected, Code actual) {
+        // 코드 동일한지 비교
+        return expected.getCode().equals(actual.getCode())
+                && expected.getCateNum().equals(actual.getCateNum())
+                && expected.getName().equals(actual.getName())
+                && expected.getChkUse().equals(actual.getChkUse())
+                && expected.getOrd().equals(actual.getOrd());
+    }
+
+}

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImplTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImplTest.java
@@ -1,0 +1,122 @@
+package com.oreo.finalproject_5re5_be.member.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.oreo.finalproject_5re5_be.member.repository.CodeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CodeServiceImplTest {
+
+    @Mock
+    private CodeRepository codeRepository;
+
+    @InjectMocks
+    private CodeServiceImpl codeService;
+
+    @BeforeEach
+    void setUp() {
+        // 자동 주입 확인
+        assertNotNull(codeRepository);
+        assertNotNull(codeService);
+    }
+
+    // 코드 등록
+    @DisplayName("코드 등록 처리")
+    @Test
+    void 코드_생성_처리() {
+        // 유효성 검증이 완료된 더미 데이터 생성
+        // 기대 결과 생성
+
+        // 리포지토리 목킹
+        // - 중복여부 false 설정
+        // - 저장된 엔티티 반환
+
+        // 서비스 메서드 호출
+        // 기대한 결과와 반환된 결과 비교
+
+    }
+
+    @DisplayName("중복된 코드명 예외 처리")
+    @Test
+    void 중복된_코드명_예외_처리() {
+        // 더미 데이터 생성
+
+        // 리포지토리 목킹
+        // - 중복여부 true 설정
+
+        // 서비스 메서드 호출
+        // 예외 발생 확인
+
+    }
+
+    // 코드 조회
+    @DisplayName("모든 코드 조회")
+    @Test
+    void 모든_코드_조회() {
+        // 기대한 결과 생성
+
+        // 리포지토리 목킹
+        // - 여러 코드 엔티티 반환 설정
+
+        // 서비스 메서드 호출
+        // 기대한 결과와 반환된 결과 비교
+    }
+
+    @DisplayName("시퀀스로 조회")
+    @Test
+    void 시퀀스로_조회() {
+        // 더미 데이터 생성
+        // 기대한 결과 생성
+
+        // 리포지토리 목킹
+        // - 시퀀스로 조회한 코드 엔티티 반환 설정
+
+        // 서비스 메서드 호출
+        // 기대한 결과와 반환된 결과 비교
+
+    }
+
+
+    @DisplayName("코드 번호로 특정 코드 조회")
+    @Test
+    void 코드_번호로_특정_코드_조회() {
+
+    }
+
+    @DisplayName("각 파트별 사용 가능한 코드 조회")
+    @Test
+    void 각_파트별_사용_가능한_코드_조회() {
+
+    }
+
+    @DisplayName("각 파트별 모든 코드 조회")
+    @Test
+    void 각_파트별_모든_코드_조회() {
+
+    }
+
+
+    // 코드 수정
+    @DisplayName("코드 수정 처리")
+    @Test
+    void 코드_수정_처리() {
+
+    }
+
+
+    // 코드 삭제
+
+    @DisplayName("코드 삭제 처리")
+    @Test
+    void 코드_삭제_처리() {
+
+    }
+
+}

--- a/src/test/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImplTest.java
+++ b/src/test/java/com/oreo/finalproject_5re5_be/member/service/CodeServiceImplTest.java
@@ -1,8 +1,17 @@
 package com.oreo.finalproject_5re5_be.member.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
+import com.oreo.finalproject_5re5_be.member.dto.request.CodeRequest;
+import com.oreo.finalproject_5re5_be.member.dto.request.CodeUpdateRequest;
+import com.oreo.finalproject_5re5_be.member.dto.response.CodeResponse;
+import com.oreo.finalproject_5re5_be.member.dto.response.CodeResponses;
+import com.oreo.finalproject_5re5_be.member.entity.Code;
+import com.oreo.finalproject_5re5_be.member.exception.CodeDuplicatedException;
 import com.oreo.finalproject_5re5_be.member.repository.CodeRepository;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,11 +29,20 @@ class CodeServiceImplTest {
     @InjectMocks
     private CodeServiceImpl codeService;
 
+    private CodeRequest request;
+    private CodeResponse response;
+    private List<Code> dummy;
+
     @BeforeEach
     void setUp() {
         // 자동 주입 확인
         assertNotNull(codeRepository);
         assertNotNull(codeService);
+
+        // 더미 데이터 생성
+        createCodeRequest();
+        createCodeResponse();
+        createDummy();
     }
 
     // 코드 등록
@@ -33,13 +51,30 @@ class CodeServiceImplTest {
     void 코드_생성_처리() {
         // 유효성 검증이 완료된 더미 데이터 생성
         // 기대 결과 생성
+        Code requestCodeEntity = request.createCodeEntity();
+        Code savedCode = Code.builder()
+                            .codeSeq(1L)
+                            .cateNum("MB")
+                            .code("MBS01")
+                            .name("신규회원")
+                            .ord(1)
+                            .chkUse("Y")
+                            .comt("신규회원 코드입니다.")
+                            .build();
+
+        createCodeResponse();
+
 
         // 리포지토리 목킹
         // - 중복여부 false 설정
         // - 저장된 엔티티 반환
+        when(codeRepository.existsByCode(anyString())).thenReturn(false);
+        when(codeRepository.save(requestCodeEntity)).thenReturn(savedCode);
 
         // 서비스 메서드 호출
         // 기대한 결과와 반환된 결과 비교
+        CodeResponse actualResponse = codeService.create(request);
+        assertEquals(response, actualResponse);
 
     }
 
@@ -50,9 +85,11 @@ class CodeServiceImplTest {
 
         // 리포지토리 목킹
         // - 중복여부 true 설정
+        when(codeRepository.existsByCode(anyString())).thenReturn(true);
 
         // 서비스 메서드 호출
         // 예외 발생 확인
+        assertThrows(CodeDuplicatedException.class, () -> codeService.create(request));
 
     }
 
@@ -61,25 +98,34 @@ class CodeServiceImplTest {
     @Test
     void 모든_코드_조회() {
         // 기대한 결과 생성
+        List<CodeResponse> responseList = dummy.stream().map(CodeResponse::of).toList();
+        CodeResponses expectedResponses = CodeResponses.of(responseList);
 
         // 리포지토리 목킹
         // - 여러 코드 엔티티 반환 설정
+        when(codeRepository.findAll()).thenReturn(dummy);
 
         // 서비스 메서드 호출
         // 기대한 결과와 반환된 결과 비교
+        CodeResponses actualResponses = codeService.readAll();
+        assertEquals(expectedResponses, actualResponses);
     }
 
     @DisplayName("시퀀스로 조회")
     @Test
     void 시퀀스로_조회() {
-        // 더미 데이터 생성
         // 기대한 결과 생성
+        Code expectedCode = dummy.get(0);
+        CodeResponse expectedResponse = CodeResponse.of(expectedCode);
 
         // 리포지토리 목킹
         // - 시퀀스로 조회한 코드 엔티티 반환 설정
+        when(codeRepository.findCodeByCodeSeq(1L)).thenReturn(expectedCode);
 
         // 서비스 메서드 호출
         // 기대한 결과와 반환된 결과 비교
+        CodeResponse actualResponse = codeService.read(1L);
+        assertEquals(expectedResponse, actualResponse);
 
     }
 
@@ -87,19 +133,63 @@ class CodeServiceImplTest {
     @DisplayName("코드 번호로 특정 코드 조회")
     @Test
     void 코드_번호로_특정_코드_조회() {
+        // 기대한 결과 생성
+        Code expectedCode = dummy.get(0);
+        CodeResponse expectedResponse = CodeResponse.of(expectedCode);
 
+        // 리포지토리 목킹
+        // - 특정 코드 번호로 조회시 반환할 코드 엔티티 설정
+        when(codeRepository.findCodeByCode("MBS01")).thenReturn(expectedCode);
+
+        // 서비스 메서드 호출
+        // 기대한 결과와 반환된 결과 비교
+        CodeResponse actualResponse = codeService.read("MBS01");
+        assertEquals(expectedResponse, actualResponse);
     }
 
     @DisplayName("각 파트별 사용 가능한 코드 조회")
     @Test
     void 각_파트별_사용_가능한_코드_조회() {
+        // 기대한 결과 생성
+        List<Code> foundCodes = dummy.stream()
+                .filter(code -> code.getCateNum().equals("MB"))
+                .filter(code -> code.getChkUse().equals("Y"))
+                .toList();
+        List<CodeResponse> responseList = foundCodes.stream()
+                .map(CodeResponse::of)
+                .toList();
+        CodeResponses expectedResponses = CodeResponses.of(responseList);
 
+        // 리포지토리 목킹
+        // - 특정 파트 번호(cateNum)으로 조회시 반환할 코드 엔티티 더미 설정
+        when(codeRepository.findAvailableCodesByCateNum("MB")).thenReturn(foundCodes);
+
+        // 서비스 메서드 호출
+        // 기대한 결과와 반환된 결과 비교
+        CodeResponses actualResponses = codeService.readAvailableCodeByCateNum("MB");
+        assertEquals(expectedResponses, actualResponses);
     }
 
     @DisplayName("각 파트별 모든 코드 조회")
     @Test
     void 각_파트별_모든_코드_조회() {
+        // 기대한 결과 생성
+        List<Code> foundCodes = dummy.stream()
+                .filter(code -> code.getCateNum().equals("MB"))
+                .toList();
+        List<CodeResponse> responseList = foundCodes.stream()
+                .map(CodeResponse::of)
+                .toList();
+        CodeResponses expectedResponses = CodeResponses.of(responseList);
 
+        // 리포지토리 목킹
+        // - 특정 파트 번호(cateNum)으로 조회시 반환할 코드 엔티티 더미 설정
+        when(codeRepository.findCodesByCateNum("MB")).thenReturn(foundCodes);
+
+        // 서비스 메서드 호출
+        // 기대한 결과와 반환된 결과 비교
+        CodeResponses actualResponses = codeService.readAllByCateNum("MB");
+        assertEquals(expectedResponses, actualResponses);
     }
 
 
@@ -107,7 +197,20 @@ class CodeServiceImplTest {
     @DisplayName("코드 수정 처리")
     @Test
     void 코드_수정_처리() {
+        // 더미 데이터 세팅
+        CodeUpdateRequest updateRequest = CodeUpdateRequest.builder()
+                                                            .name("신규회원 수정")
+                                                            .ord(2)
+                                                            .chkUse("N")
+                                                            .comt("신규회원 수정 코드입니다.")
+                                                            .build();
 
+        // 리포지토리 목킹
+        // - 시퀀스로 조회한 코드 엔티티 반환 설정
+        when(codeRepository.findCodeByCodeSeq(1L)).thenReturn(dummy.get(0));
+
+        // 서비스 호출
+        assertDoesNotThrow(() -> codeService.update(1L, updateRequest));
     }
 
 
@@ -116,7 +219,78 @@ class CodeServiceImplTest {
     @DisplayName("코드 삭제 처리")
     @Test
     void 코드_삭제_처리() {
+        // 더미 데이터 세팅
 
+        // 리포지토리 목킹
+        when(codeRepository.findCodeByCodeSeq(1L)).thenReturn(dummy.get(0));
+
+        // 서비스 호출
+        assertDoesNotThrow(() -> codeService.delete(1L));
+    }
+
+
+    private void createCodeRequest() {
+        request = CodeRequest.builder()
+                .cateNum("MB")
+                .code("MBS01")
+                .name("신규회원")
+                .ord(1)
+                .chkUse("Y")
+                .comt("신규회원 코드입니다.")
+                .build();
+    }
+
+    private void createCodeResponse() {
+        response = CodeResponse.builder()
+                .codeSeq(1L)
+                .cateNum("MB")
+                .code("MBS01")
+                .name("신규회원")
+                .ord(1)
+                .chkUse("Y")
+                .comt("신규회원 코드입니다.")
+                .build();
+    }
+
+    private void createDummy() {
+        dummy = List.of(
+                Code.builder()
+                        .codeSeq(1L)
+                        .cateNum("MB")
+                        .code("MBS01")
+                        .name("신규회원")
+                        .ord(1)
+                        .chkUse("Y")
+                        .comt("신규회원 코드입니다.")
+                        .build(),
+                Code.builder()
+                        .codeSeq(2L)
+                        .cateNum("MB")
+                        .code("MBS02")
+                        .name("기존회원")
+                        .ord(2)
+                        .chkUse("Y")
+                        .comt("기존회원 코드입니다.")
+                        .build(),
+                Code.builder()
+                        .codeSeq(3L)
+                        .cateNum("MB")
+                        .code("MBS03")
+                        .name("탈퇴회원")
+                        .ord(3)
+                        .chkUse("Y")
+                        .comt("탈퇴회원 코드입니다.")
+                        .build(),
+                Code.builder()
+                        .codeSeq(4L)
+                        .cateNum("TTS")
+                        .code("TTS01")
+                        .name("생성")
+                        .ord(3)
+                        .chkUse("Y")
+                        .comt("TTS 작업 코드입니다.")
+                        .build()
+        );
     }
 
 }


### PR DESCRIPTION
## 내용 
> - 통합 코드 테이블 사용할 수 있도록 구현했습니다~

## 참고 사항
> - 통합 코드 기능을 global에다 관리하려 했으나 컨트롤러, 서비스, 리포지토리도 그 쪽에 만들어야 하는지 고민이 되서 일단 회원 파트에 넣고 구현했습니다.
> - 추후에 이 부분 어디다 배치할지 논의 했으면 좋겠습니다!