### PR TITLE
[Feat] `ConcatRowService` 생성, 수정, 조회 구현

### DIFF
--- a/src/main/java/com/oreo/finalproject_5re5_be/concat/dto/ConcatRowDto.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/concat/dto/ConcatRowDto.java
@@ -1,0 +1,18 @@
+package com.oreo.finalproject_5re5_be.concat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class ConcatRowDto {
+    private Long concatRowSequence;
+    private Long projectSequence;
+    private String rowText;
+    private Character selected;
+    private Character status;
+    private Float silence;
+    private Integer rowIndex;
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/concat/dto/request/ConcatRowSaveRequestDto.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/concat/dto/request/ConcatRowSaveRequestDto.java
@@ -1,0 +1,16 @@
+package com.oreo.finalproject_5re5_be.concat.dto.request;
+
+import com.oreo.finalproject_5re5_be.concat.dto.ConcatRowDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@ToString
+@Getter
+@AllArgsConstructor
+public class ConcatRowSaveRequestDto {
+    private Long concatTabId;
+    private List<ConcatRowDto> concatRowRequests;
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/concat/entity/ConcatRow.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/concat/entity/ConcatRow.java
@@ -1,35 +1,41 @@
 package com.oreo.finalproject_5re5_be.concat.entity;
 
 import com.oreo.finalproject_5re5_be.global.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.*;
 
 @ToString
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity(name = "concat_row")
 public class ConcatRow extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "concet_row_seq")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "concat_row_seq_generator")
+    @SequenceGenerator(
+            name = "concat_row_seq_generator",
+            sequenceName = "concat_row_seq", // 실제 시퀀스 이름
+            allocationSize = 1              // ID를 하나씩 할당
+    )
+    @Column(name = "concat_row_seq")
     private Long concatRowSeq;
+
 
     @ManyToOne
     @JoinColumn(name = "pro_seq")
     private ConcatTab concatTab;
 
+    @Column(name = "row_text")
     private String rowText;
+    @Column(name = "selected")
     private Character selected;
+    @Column(name = "silence")
     private Float silence;
+    @Column(name = "row_index")
     private Integer rowIndex;
+    @Column(name = "status")
     private Character status;
 
 

--- a/src/main/java/com/oreo/finalproject_5re5_be/concat/repository/ConcatRowRepository.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/concat/repository/ConcatRowRepository.java
@@ -2,8 +2,23 @@ package com.oreo.finalproject_5re5_be.concat.repository;
 
 import com.oreo.finalproject_5re5_be.concat.entity.ConcatRow;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ConcatRowRepository extends JpaRepository<ConcatRow, Long> {
+    List<ConcatRow> findByStatusAndConcatTab_Project_ProSeq(Character status, Long projectSeq);
+    @Modifying
+    @Query(value = "UPDATE concat_row " +
+            "SET status = :status " +
+            "WHERE concat_row_seq IN :concatRowSeq",
+            nativeQuery = true)
+    int updateStatusByConcatRowSeq(@Param("concatRowSeq") List<Long> concatRowSeq,
+                                   @Param("status") Character status);
+
+    List<ConcatRow> findByConcatRowSeq(long concatRowSequence);
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/concat/service/ConcatRowService.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/concat/service/ConcatRowService.java
@@ -1,0 +1,130 @@
+package com.oreo.finalproject_5re5_be.concat.service;
+
+import com.oreo.finalproject_5re5_be.concat.dto.ConcatRowDto;
+import com.oreo.finalproject_5re5_be.concat.dto.request.ConcatRowSaveRequestDto;
+import com.oreo.finalproject_5re5_be.concat.entity.ConcatRow;
+import com.oreo.finalproject_5re5_be.concat.entity.ConcatTab;
+import com.oreo.finalproject_5re5_be.concat.repository.ConcatRowRepository;
+import com.oreo.finalproject_5re5_be.concat.repository.ConcatTabRepository;
+import com.oreo.finalproject_5re5_be.concat.service.helper.ConcatRowHelper;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+
+public class ConcatRowService {
+    private ConcatRowRepository concatRowRepository;
+    private ConcatTabRepository concatTabRepository;
+    private final ConcatRowHelper concatRowHelper;
+
+    //현재 Hibernate에서 데이터 무결성 확인을 위해 자동으로 project, concat_tab, concat_option을 확인 하는 쿼리를 생성함
+    //
+    @Transactional
+    public boolean saveConcatRows(ConcatRowSaveRequestDto requestDto) {
+        Optional<ConcatTab> concatTabOpt = concatTabRepository.findById(requestDto.getConcatTabId());
+
+        if (concatTabOpt.isPresent()) {
+            ConcatTab concatTab = concatTabOpt.get();
+            List<ConcatRow> concatRowStream = requestDto.getConcatRowRequests()
+                    .stream().map(crr -> ConcatRow.builder()
+                            .concatTab(concatTab)
+                            .rowText(crr.getRowText())
+                            .selected(crr.getSelected())
+                            .status(crr.getStatus())
+                            .silence(crr.getSilence())
+                            .rowIndex(crr.getRowIndex())
+                            .build()).toList();
+            concatRowHelper.batchInsert(concatRowStream);
+            return true;
+        }
+        return false;
+    }
+
+    public List<ConcatRowDto> readRecentConcatRows(long projectSequence) {
+        List<ConcatRow> concatRows = concatRowRepository
+                .findByStatusAndConcatTab_Project_ProSeq('Y', projectSequence);
+        if (concatRows.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return concatRows.stream().map(cr -> ConcatRowDto.builder()
+                .concatRowSequence(cr.getConcatRowSeq())
+                .rowText(cr.getRowText())
+                .rowIndex(cr.getRowIndex())
+                .selected(cr.getSelected())
+                .silence(cr.getSilence())
+                .build()
+        ).toList();
+    }
+
+    public List<ConcatRowDto> readConcatRows(long concatRowSequence) {
+        List<ConcatRow> concatRows = concatRowRepository
+                .findByConcatRowSeq(concatRowSequence);
+        if (concatRows.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return concatRows.stream().map(cr -> ConcatRowDto.builder()
+                .concatRowSequence(cr.getConcatRowSeq())
+                .rowText(cr.getRowText())
+                .rowIndex(cr.getRowIndex())
+                .selected(cr.getSelected())
+                .silence(cr.getSilence())
+                .build()
+        ).toList();
+    }
+
+    @Transactional
+    public boolean disableConcatRows(ConcatRowSaveRequestDto requestDto) {
+        Optional<ConcatTab> concatTabOpt = concatTabRepository.findById(requestDto.getConcatTabId());
+
+        if (concatTabOpt.isPresent()) {
+
+            List<Long> concatRowSeq = requestDto.getConcatRowRequests()
+                    .stream().map(ConcatRowDto::getConcatRowSequence).toList();
+            concatRowRepository.updateStatusByConcatRowSeq(concatRowSeq, 'N');//행 비활성 처리
+            return true;
+        }
+        return false;
+    }
+
+
+    @Transactional(rollbackOn = Exception.class)//모든 예외에 대해 롤백 수행
+    public boolean updateConcatRows(ConcatRowSaveRequestDto requestDto) {
+        Optional<ConcatTab> concatTabOpt = concatTabRepository.findById(requestDto.getConcatTabId());
+
+        if (concatTabOpt.isPresent()) {
+            ConcatTab concatTab = concatTabOpt.get();
+            return disableConcatRowsForUpdate(requestDto.getConcatRowRequests()) &&
+                    createConcatRowsForUpdate(requestDto.getConcatRowRequests(), concatTab);
+        }
+        return false;
+    }
+
+    private boolean createConcatRowsForUpdate(List<ConcatRowDto> requestDto, ConcatTab concatTab) {
+        List<ConcatRow> concatRowStream = requestDto
+                .stream().filter(cr -> cr.getStatus() != 'N')
+                .map(crr -> ConcatRow.builder()
+                        .concatTab(concatTab)
+                        .rowText(crr.getRowText())
+                        .selected(crr.getSelected())
+                        .status(crr.getStatus())
+                        .silence(crr.getSilence())
+                        .rowIndex(crr.getRowIndex())
+                        .build()).toList();
+        concatRowHelper.batchInsert(concatRowStream);
+        return true;
+    }
+
+    private boolean disableConcatRowsForUpdate(List<ConcatRowDto> concatRows) {
+
+        List<Long> concatRowSeq = concatRows
+                .stream().map(ConcatRowDto::getConcatRowSequence).toList();
+        //행 비활성 처리
+        return concatRowRepository.updateStatusByConcatRowSeq(concatRowSeq, 'N') != 0;
+    }
+}

--- a/src/main/java/com/oreo/finalproject_5re5_be/concat/service/helper/ConcatRowHelper.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/concat/service/helper/ConcatRowHelper.java
@@ -1,0 +1,28 @@
+package com.oreo.finalproject_5re5_be.concat.service.helper;
+
+import com.oreo.finalproject_5re5_be.concat.entity.ConcatRow;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ConcatRowHelper {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional
+    public void batchInsert(List<ConcatRow> rows) {
+        for (int i = 0; i < rows.size(); i++) {
+            entityManager.persist(rows.get(i));
+            if (i > 0 && i % 20 == 0) { // 20개마다 flush & clear
+                entityManager.flush();
+                entityManager.clear();
+            }
+        }
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=FinalProject_5RE5_BE
 
 # Database
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/OREOPARK
+Cspring.datasource.url=jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/OREOPARK?rewriteBatchedStatements=true
 spring.datasource.username=${MYSQL_USER}
 spring.datasource.password=${MYSQL_PASSWORD}
 
@@ -22,3 +22,9 @@ aws.s3.accessKey=${AWS_S3_ACCESSKEY}
 aws.s3.secretKey=${AWS_S3_SECRETKEY}
 aws.s3.region=${AWS_S3_REGION}
 aws.s3.bucket=${AWS_S3_BUKET_NAME}
+
+
+spring.jpa.properties.hibernate.jdbc.batch_size=20
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.generate_statistics=true


### PR DESCRIPTION
## 작업 내용

- 배치 처리를 위해 `properties` 설정 추가
- 배치 처리를 위해 `ConcatRow` 테이블 ID 생성 전략 변경


### 생성
- 생성시 요청된 Dto의 모든 데이터 삽입

### 조회
- `concatRowSeq` 조회
- `projectSeq`, `Status` 'Y'인 행 조회

### 수정
- 수정 요청된 모든 행 `status` 'N'으로 변경
- 요청 된 행 중 `status`가 'N'인 행을 제외한 모든 행 삽입

### 이슈

- close #142 